### PR TITLE
Add app version and reorganize settings sections

### DIFF
--- a/NativeAppTemplate/Constants.swift
+++ b/NativeAppTemplate/Constants.swift
@@ -220,7 +220,6 @@ extension String {
 
     static let myAccount = "My Account"
     static let profile = "Profile"
-    static let information = "Information"
     static let supportWebsite = "Support Website"
     static let howToUse = "How To Use"
     static let faqs = "FAQs"

--- a/NativeAppTemplate/UI/Settings/SettingsView.swift
+++ b/NativeAppTemplate/UI/Settings/SettingsView.swift
@@ -52,11 +52,7 @@ struct SettingsView: View {
                 }
                 .listRowBackground(Color.cardBackground.opacity(0.7))
 
-                Section(header: Text(String.information)) {
-                    Link(destination: URL(string: String.supportWebsiteUrl)!) {
-                        Label(String.supportWebsite, systemImage: "globe")
-                    }
-
+                Section(header: Text(verbatim: "Support")) {
                     Link(destination: URL(string: String.howToUseUrl)!) {
                         Label(String.howToUse, systemImage: "info")
                     }
@@ -74,12 +70,28 @@ struct SettingsView: View {
                     } label: {
                         Label(String.rateApp, systemImage: "hand.thumbsup")
                     }
+                }
+                .listRowBackground(Color.cardBackground.opacity(0.7))
 
+                Section(header: Text(verbatim: "About")) {
+                    Link(destination: URL(string: String.supportWebsiteUrl)!) {
+                        Label("Website", systemImage: "globe")
+                    }
                     Link(destination: URL(string: String.privacyPolicyUrl)!) {
-                        Text(String.privacyPolicy)
+                        Label(String.privacyPolicy, systemImage: "hand.raised")
                     }
                     Link(destination: URL(string: String.termsOfUseUrl)!) {
-                        Text(String.termsOfUse)
+                        Label(String.termsOfUse, systemImage: "doc.text")
+                    }
+                }
+                .listRowBackground(Color.cardBackground.opacity(0.7))
+
+                Section(header: Text(verbatim: "App")) {
+                    HStack {
+                        Text(verbatim: "Version")
+                        Spacer()
+                        Text(appVersion)
+                            .foregroundStyle(.secondary)
                     }
                 }
                 .listRowBackground(Color.cardBackground.opacity(0.7))
@@ -107,6 +119,10 @@ struct SettingsView: View {
         }
         .navigationTitle(String.settings)
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var appVersion: String {
+        "\(Bundle.main.appVersionLong) (\(Bundle.main.appBuild))"
     }
 
     var supportEmailURL: URL {


### PR DESCRIPTION
## Summary
- Split Information section into Support (How To Use, FAQs, Contact, Rate App) and About (Website, Privacy Policy, Terms of Use)
- Add app version display in new App section
- Use `Text(verbatim:)` for non-localized labels
- Remove unused `information` constant

## Test plan
- [x] Verify app version displays correctly in the App section
- [x] Verify Support section contains How To Use, FAQs, Contact, Rate App
- [x] Verify About section contains Website, Privacy Policy, Terms of Use
- [x] Verify all links open correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)