### PR TITLE
Read API endpoint from env vars in Debug builds

### DIFF
--- a/NativeAppTemplate/Constants.swift
+++ b/NativeAppTemplate/Constants.swift
@@ -94,9 +94,10 @@ enum NativeAppTemplateConstants {
 
 extension String {
     #if DEBUG
-    static let scheme: String = ProcessInfo.processInfo.environment["NATEMPLATE_API_SCHEME"] ?? "https"
-    static let domain: String = ProcessInfo.processInfo.environment["NATEMPLATE_API_DOMAIN"] ?? "api.nativeapptemplate.com"
-    static let port: String = ProcessInfo.processInfo.environment["NATEMPLATE_API_PORT"] ?? ""
+    private static let env = ProcessInfo.processInfo.environment
+    static let scheme: String = env["NATEMPLATE_API_SCHEME"] ?? "https"
+    static let domain: String = env["NATEMPLATE_API_DOMAIN"] ?? "api.nativeapptemplate.com"
+    static let port: String = env["NATEMPLATE_API_PORT"] ?? ""
     #else
     static let scheme: String = "https"
     static let domain: String = "api.nativeapptemplate.com"

--- a/NativeAppTemplate/Constants.swift
+++ b/NativeAppTemplate/Constants.swift
@@ -94,12 +94,9 @@ enum NativeAppTemplateConstants {
 
 extension String {
     #if DEBUG
-    //  static let scheme: String = "http"
-    //  static let domain: String = "192.168.1.21"
-    //  static let port: String = "3000"
-    static let scheme: String = "https"
-    static let domain: String = "api.nativeapptemplate.com"
-    static let port: String = ""
+    static let scheme: String = ProcessInfo.processInfo.environment["NATEMPLATE_API_SCHEME"] ?? "https"
+    static let domain: String = ProcessInfo.processInfo.environment["NATEMPLATE_API_DOMAIN"] ?? "api.nativeapptemplate.com"
+    static let port:   String = ProcessInfo.processInfo.environment["NATEMPLATE_API_PORT"]   ?? ""
     #else
     static let scheme: String = "https"
     static let domain: String = "api.nativeapptemplate.com"

--- a/NativeAppTemplate/Constants.swift
+++ b/NativeAppTemplate/Constants.swift
@@ -96,7 +96,7 @@ extension String {
     #if DEBUG
     static let scheme: String = ProcessInfo.processInfo.environment["NATEMPLATE_API_SCHEME"] ?? "https"
     static let domain: String = ProcessInfo.processInfo.environment["NATEMPLATE_API_DOMAIN"] ?? "api.nativeapptemplate.com"
-    static let port:   String = ProcessInfo.processInfo.environment["NATEMPLATE_API_PORT"]   ?? ""
+    static let port: String = ProcessInfo.processInfo.environment["NATEMPLATE_API_PORT"] ?? ""
     #else
     static let scheme: String = "https"
     static let domain: String = "api.nativeapptemplate.com"

--- a/NativeAppTemplateTests/UI/Shop Settings/NumberTagsWebpageListViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Settings/NumberTagsWebpageListViewModelTest.swift
@@ -121,7 +121,7 @@ struct NumberTagsWebpageListViewModelTest {
             itemTagsCount: 10,
             scannedItemTagsCount: 5,
             completedItemTagsCount: 3,
-            displayShopServerPath: "https://api.nativeapptemplate.com/display/shops/\(id)?type=server"
+            displayShopServerPath: "/display/shops/\(id)?type=server"
         )
     }
 }

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ NATEMPLATE_API_DOMAIN = <your-lan-ip>
 NATEMPLATE_API_PORT   = 3000
 ```
 
+> **Note:** Never use `127.0.0.1`, `localhost`, or `0.0.0.0` for `NATEMPLATE_API_DOMAIN` — those resolve to the iOS Simulator/device itself, not your Mac. Use your Mac's LAN IP (e.g., `192.168.1.6`) so the simulator or a physical device can reach the API server.
+
 Keep the scheme in `xcuserdata` (per-developer, gitignored), not `xcshareddata`. In Xcode, open **Product → Scheme → Manage Schemes…**, find `NativeAppTemplate`, and **uncheck "Shared"**. This moves the scheme (with your local env vars) to `xcuserdata/<user>.xcuserdatad/xcschemes/` so your API settings are not committed. If Xcode staged a deletion of the previously shared scheme, restore it with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -141,13 +141,21 @@ To run this app successfully, ensure you have:
 
 ## Running with the NativeAppTemplate-API on localhost
 
-To connect to a local API server, update the following configuration in in Constants.swift:
+To connect to a local API server, set these env vars on the Xcode scheme (Edit Scheme → Run → Arguments → Environment Variables):
 
-```swift
-static let scheme: String = "http"
-static let domain: String = "192.168.1.21"
-static let port: String = "3000"
 ```
+NATEMPLATE_API_SCHEME = http
+NATEMPLATE_API_DOMAIN = <your-lan-ip>
+NATEMPLATE_API_PORT   = 3000
+```
+
+Keep the scheme in `xcuserdata` (per-developer, gitignored), not `xcshareddata`. In Xcode, open **Product → Scheme → Manage Schemes…**, find `NativeAppTemplate`, and **uncheck "Shared"**. This moves the scheme (with your local env vars) to `xcuserdata/<user>.xcuserdatad/xcschemes/` so your API settings are not committed. If Xcode staged a deletion of the previously shared scheme, restore it with:
+
+```bash
+git restore --source=HEAD --staged --worktree NativeAppTemplate.xcodeproj/xcshareddata/xcschemes/NativeAppTemplate.xcscheme
+```
+
+Debug builds read these at launch via `ProcessInfo.processInfo.environment` in `Constants.swift`; when unset, they fall back to the production defaults (`https://api.nativeapptemplate.com`). Release builds always use the production defaults.
 
 ## SwiftLint
 


### PR DESCRIPTION
## Summary
- `Constants.swift` debug build now reads `NATEMPLATE_API_SCHEME`, `NATEMPLATE_API_DOMAIN`, `NATEMPLATE_API_PORT` from `ProcessInfo.processInfo.environment`, falling back to the hosted production values when unset.
- Prefix is `NATEMPLATE_API_*` to avoid collision with the widely-used `API_*` namespace (`API_KEY`, `API_URL`, `API_TOKEN`).
- Release builds are unchanged and always hit `https://api.nativeapptemplate.com`.
- `README.md` updated to describe setting scheme env vars in Xcode (per-developer, keep the scheme in `xcuserdata`) instead of editing `Constants.swift`.

## Test plan
- [ ] In Xcode, Edit Scheme → Run → Environment Variables set `NATEMPLATE_API_SCHEME=http`, `NATEMPLATE_API_DOMAIN=<lan-ip>`, `NATEMPLATE_API_PORT=3000`; Debug build connects to the local Rails API
- [ ] With all three env vars unset, Debug build falls back to `https://api.nativeapptemplate.com`
- [ ] Release build always uses the hosted defaults regardless of env
- [ ] Scheme lives under `xcuserdata/` (per-dev, gitignored), not `xcshareddata/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)