### PR TITLE
Silence success toasts on item-tag complete/idle in ShopDetailView

### DIFF
--- a/NativeAppTemplate/Constants.swift
+++ b/NativeAppTemplate/Constants.swift
@@ -204,9 +204,7 @@ extension String {
     static let itemTagUpdated = "Tag updated successfully."
     static let itemTagDeleted = "Tag deleted successfully."
     static let itemTagDeletedError = "There was a problem deleting the tag."
-    static let itemTagCompleted = "Tag completed successfully."
     static let itemTagCompletedError = "There was a problem completing the tag."
-    static let itemTagIdled = "Tag idled successfully."
     static let itemTagIdledError = "There was a problem idling the tag."
 
     static let shopkeeperCreated = "Account created successfully."

--- a/NativeAppTemplate/UI/Shop Detail/ShopDetailViewModel.swift
+++ b/NativeAppTemplate/UI/Shop Detail/ShopDetailViewModel.swift
@@ -76,7 +76,6 @@ final class ShopDetailViewModel {
 
             do {
                 _ = try await itemTagRepository.complete(id: itemTagId)
-                messageBus.post(message: Message(level: .success, message: .itemTagCompleted))
             } catch {
                 messageBus.post(
                     message: Message(
@@ -98,7 +97,6 @@ final class ShopDetailViewModel {
 
             do {
                 _ = try await itemTagRepository.idle(id: itemTagId)
-                messageBus.post(message: Message(level: .success, message: .itemTagIdled))
             } catch {
                 messageBus.post(
                     message: Message(

--- a/NativeAppTemplateTests/UI/Shop Detail/ShopDetailViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Detail/ShopDetailViewModelTest.swift
@@ -143,9 +143,7 @@ struct ShopDetailViewModelTest { // swiftlint:disable:this type_body_length
         }
         await completeTagTask.value
 
-        let message = String.itemTagCompleted
-
-        #expect(viewModel.messageBus.currentMessage?.message == message)
+        #expect(viewModel.messageBus.currentMessage == nil)
     }
 
     @Test
@@ -211,9 +209,7 @@ struct ShopDetailViewModelTest { // swiftlint:disable:this type_body_length
         }
         await idleTagTask.value
 
-        let message = String.itemTagIdled
-
-        #expect(viewModel.messageBus.currentMessage?.message == message)
+        #expect(viewModel.messageBus.currentMessage == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary
Ports [nativeapptemplate/NativeAppTemplate-iOS#52](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/52). The swipe action on `ShopDetailView` already reflects the state change via `ShopDetailCardView`'s re-render after `reload()`; the extra success toast (`itemTagCompleted` / `itemTagIdled`) was redundant noise. Errors still post to the message bus, so users still see feedback when something actually fails.

### Changes
- `ShopDetailViewModel.completeTag` / `idleTag`: dropped the success \`messageBus.post(...)\` calls.
- `ShopDetailViewModelTest.completeTag` / `idleTag`: now assert \`currentMessage == nil\` on success (failure tests unchanged).
- `Constants.swift`: removed the now-unused \`itemTagCompleted\` / \`itemTagIdled\` strings; kept the \`*Error\` variants.

## Test plan
- [x] \`xcodebuild build-for-testing\` — \`** TEST BUILD SUCCEEDED **\`
- [x] \`make lint\` — \`0 violations\`
- [ ] \`xcodebuild test\` passes (please verify in Xcode with Cmd+U)
- [ ] Manual simulator smoke test: swipe-to-complete and swipe-to-idle no longer show a green success toast; failure case still shows red error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)