### PR TITLE
Drop maximum_name_length from permissions; move to Constants

### DIFF
--- a/NativeAppTemplate/App.swift
+++ b/NativeAppTemplate/App.swift
@@ -36,7 +36,6 @@ private final class NullSessionController: SessionControllerProtocol {
     var shouldUpdateApp: Bool = false
     var shouldUpdatePrivacy: Bool = false
     var shouldUpdateTerms: Bool = false
-    var maximumNameLength: Int = 100
     var shopLimitCount: Int = 0
     var shopkeeper: Shopkeeper?
     var hasPermissions: Bool {

--- a/NativeAppTemplate/Constants.swift
+++ b/NativeAppTemplate/Constants.swift
@@ -74,6 +74,7 @@ enum NativeAppTemplateConstants {
 
     // MARK: - ItemTag
 
+    static let maximumItemTagNameLength = 100
     static let maximumItemTagDescriptionLength = 1_000
 
     // MARK: - Corner Radius

--- a/NativeAppTemplate/Networking/Requests/PermissionsRequest.swift
+++ b/NativeAppTemplate/Networking/Requests/PermissionsRequest.swift
@@ -9,7 +9,6 @@ struct PermissionsResponse: Sendable {
     var iosAppVersion: Int
     var shouldUpdatePrivacy: Bool
     var shouldUpdateTerms: Bool
-    var maximumNameLength: Int
     var shopLimitCount: Int
 }
 
@@ -49,8 +48,6 @@ struct PermissionsRequest: Request {
             throw NativeAppTemplateAPIError.responseMissingRequiredMeta(field: "should_update_terms")
         }
 
-        let maximumNameLength = doc.meta["maximum_name_length"] as? Int ?? 100
-
         guard let shopLimitCount = doc.meta["shop_limit_count"] as? Int else {
             throw NativeAppTemplateAPIError.responseMissingRequiredMeta(field: "shop_limit_count")
         }
@@ -59,7 +56,6 @@ struct PermissionsRequest: Request {
             iosAppVersion: iosAppVersion,
             shouldUpdatePrivacy: shouldUpdatePrivacy,
             shouldUpdateTerms: shouldUpdateTerms,
-            maximumNameLength: maximumNameLength,
             shopLimitCount: shopLimitCount
         )
     }

--- a/NativeAppTemplate/Sessions/SessionController.swift
+++ b/NativeAppTemplate/Sessions/SessionController.swift
@@ -18,7 +18,6 @@ import Observation
     var shouldUpdateApp = false
     var shouldUpdatePrivacy = false
     var shouldUpdateTerms = false
-    var maximumNameLength = 100
     var shopLimitCount = 0
 
     var shopkeeper: Shopkeeper? {
@@ -171,8 +170,6 @@ import Observation
                 shouldUpdateApp = Int(Bundle.main.appBuild)! < permissionsResponse.iosAppVersion
                 shouldUpdatePrivacy = permissionsResponse.shouldUpdatePrivacy
                 shouldUpdateTerms = permissionsResponse.shouldUpdateTerms
-                maximumNameLength = permissionsResponse.maximumNameLength
-
                 shopLimitCount = permissionsResponse.shopLimitCount
 
                 didFetchPermissions = true

--- a/NativeAppTemplate/Sessions/SessionControllerProtocol.swift
+++ b/NativeAppTemplate/Sessions/SessionControllerProtocol.swift
@@ -38,7 +38,6 @@ protocol SessionControllerProtocol: AnyObject, Observable, Sendable {
     var shouldUpdateApp: Bool { get set }
     var shouldUpdatePrivacy: Bool { get set }
     var shouldUpdateTerms: Bool { get set }
-    var maximumNameLength: Int { get set }
     var shopLimitCount: Int { get set }
 
     var shopkeeper: Shopkeeper? { get set }

--- a/NativeAppTemplate/UI/Shop Settings/ItemTag Detail/ItemTagDetailView.swift
+++ b/NativeAppTemplate/UI/Shop Settings/ItemTag Detail/ItemTagDetailView.swift
@@ -61,7 +61,6 @@ private extension ItemTagDetailView {
                     viewModel: ItemTagEditViewModel(
                         itemTagRepository: dataManager.itemTagRepository,
                         messageBus: messageBus,
-                        sessionController: dataManager.sessionController,
                         itemTagId: viewModel.itemTagId
                     )
                 )

--- a/NativeAppTemplate/UI/Shop Settings/ItemTag Detail/ItemTagEditViewModel.swift
+++ b/NativeAppTemplate/UI/Shop Settings/ItemTag Detail/ItemTagEditViewModel.swift
@@ -18,18 +18,15 @@ final class ItemTagEditViewModel {
 
     private let itemTagRepository: ItemTagRepositoryProtocol
     private let messageBus: MessageBus
-    private let sessionController: SessionControllerProtocol
     private let itemTagId: String
 
     init(
         itemTagRepository: ItemTagRepositoryProtocol,
         messageBus: MessageBus,
-        sessionController: SessionControllerProtocol,
         itemTagId: String
     ) {
         self.itemTagRepository = itemTagRepository
         self.messageBus = messageBus
-        self.sessionController = sessionController
         self.itemTagId = itemTagId
     }
 
@@ -70,7 +67,7 @@ final class ItemTagEditViewModel {
     }
 
     var maximumNameLength: Int {
-        sessionController.maximumNameLength
+        NativeAppTemplateConstants.maximumItemTagNameLength
     }
 
     var maximumDescriptionLength: Int {

--- a/NativeAppTemplate/UI/Shop Settings/ItemTag List/ItemTagCreateViewModel.swift
+++ b/NativeAppTemplate/UI/Shop Settings/ItemTag List/ItemTagCreateViewModel.swift
@@ -16,18 +16,15 @@ final class ItemTagCreateViewModel {
 
     private let itemTagRepository: ItemTagRepositoryProtocol
     private let messageBus: MessageBus
-    private let sessionController: SessionControllerProtocol
     private let shopId: String
 
     init(
         itemTagRepository: ItemTagRepositoryProtocol,
         messageBus: MessageBus,
-        sessionController: SessionControllerProtocol,
         shopId: String
     ) {
         self.itemTagRepository = itemTagRepository
         self.messageBus = messageBus
-        self.sessionController = sessionController
         self.shopId = shopId
     }
 
@@ -54,7 +51,7 @@ final class ItemTagCreateViewModel {
     }
 
     var maximumNameLength: Int {
-        sessionController.maximumNameLength
+        NativeAppTemplateConstants.maximumItemTagNameLength
     }
 
     var maximumDescriptionLength: Int {

--- a/NativeAppTemplate/UI/Shop Settings/ItemTag List/ItemTagListView.swift
+++ b/NativeAppTemplate/UI/Shop Settings/ItemTag List/ItemTagListView.swift
@@ -111,7 +111,6 @@ private extension ItemTagListView {
                     viewModel: ItemTagCreateViewModel(
                         itemTagRepository: dataManager.itemTagRepository,
                         messageBus: messageBus,
-                        sessionController: dataManager.sessionController,
                         shopId: viewModel.shop.id
                     )
                 )

--- a/NativeAppTemplateTests/Testing/Repositories/TestSessionController.swift
+++ b/NativeAppTemplateTests/Testing/Repositories/TestSessionController.swift
@@ -21,7 +21,6 @@ import Foundation
     public var shouldUpdateTerms: Bool = false
     public var shouldThrowPrivacyError: Bool = false
     public var shouldThrowTermsError: Bool = false
-    public var maximumNameLength: Int = 100
     public var shopLimitCount: Int = 1
 
     public var shopkeeper: Shopkeeper?

--- a/NativeAppTemplateTests/UI/Shop Settings/ItemTag Detail/ItemTagEditViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Settings/ItemTag Detail/ItemTagEditViewModelTest.swift
@@ -10,7 +10,6 @@ import Testing
 @MainActor
 @Suite
 struct ItemTagEditViewModelTest {
-    let sessionController = TestSessionController()
     let itemTagRepository = TestItemTagRepository(
         itemTagsService: ItemTagsService()
     )
@@ -36,7 +35,6 @@ struct ItemTagEditViewModelTest {
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
@@ -50,16 +48,14 @@ struct ItemTagEditViewModelTest {
 
     @Test
     func maximumNameLength() {
-        sessionController.maximumNameLength = 6
 
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
-        #expect(viewModel.maximumNameLength == 6)
+        #expect(viewModel.maximumNameLength == 100)
     }
 
     @Test
@@ -67,7 +63,6 @@ struct ItemTagEditViewModelTest {
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
@@ -79,7 +74,6 @@ struct ItemTagEditViewModelTest {
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
@@ -101,7 +95,6 @@ struct ItemTagEditViewModelTest {
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
@@ -126,7 +119,6 @@ struct ItemTagEditViewModelTest {
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
@@ -151,13 +143,11 @@ struct ItemTagEditViewModelTest {
         (String(repeating: "x", count: 101), true)   // 101 → invalid
     ])
     func nameValidation(name: String, shouldBeInvalid: Bool) async {
-        sessionController.maximumNameLength = 100
         itemTagRepository.setItemTags(itemTags: [testItemTag])
 
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
@@ -183,7 +173,6 @@ struct ItemTagEditViewModelTest {
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
@@ -204,7 +193,6 @@ struct ItemTagEditViewModelTest {
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
@@ -238,19 +226,17 @@ struct ItemTagEditViewModelTest {
 
     @Test
     func validateNameLengthTruncatesCorrectly() {
-        sessionController.maximumNameLength = 3
 
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
-        viewModel.name = "ABCDEFGH"
+        viewModel.name = String(repeating: "A", count: 100) + "EXTRA"
         viewModel.validateNameLength()
 
-        #expect(viewModel.name == "ABC")
+        #expect(viewModel.name == String(repeating: "A", count: 100))
     }
 
     @Test
@@ -258,7 +244,6 @@ struct ItemTagEditViewModelTest {
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
@@ -275,7 +260,6 @@ struct ItemTagEditViewModelTest {
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
@@ -310,7 +294,6 @@ struct ItemTagEditViewModelTest {
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 
@@ -344,7 +327,6 @@ struct ItemTagEditViewModelTest {
         let viewModel = ItemTagEditViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             itemTagId: itemTagId
         )
 

--- a/NativeAppTemplateTests/UI/Shop Settings/ItemTag List/ItemTagCreateViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Settings/ItemTag List/ItemTagCreateViewModelTest.swift
@@ -10,7 +10,6 @@ import Testing
 @MainActor
 @Suite
 struct ItemTagCreateViewModelTest {
-    let sessionController = TestSessionController()
     let itemTagRepository = TestItemTagRepository(
         itemTagsService: ItemTagsService()
     )
@@ -22,7 +21,6 @@ struct ItemTagCreateViewModelTest {
         let viewModel = ItemTagCreateViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             shopId: shopId
         )
 
@@ -35,16 +33,14 @@ struct ItemTagCreateViewModelTest {
 
     @Test
     func maximumNameLength() {
-        sessionController.maximumNameLength = 5
 
         let viewModel = ItemTagCreateViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             shopId: shopId
         )
 
-        #expect(viewModel.maximumNameLength == 5)
+        #expect(viewModel.maximumNameLength == 100)
     }
 
     @Test
@@ -52,7 +48,6 @@ struct ItemTagCreateViewModelTest {
         let viewModel = ItemTagCreateViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             shopId: shopId
         )
 
@@ -69,12 +64,10 @@ struct ItemTagCreateViewModelTest {
         (String(repeating: "a", count: 101), true)   // 101 → invalid
     ])
     func nameValidation(name: String, shouldBeInvalid: Bool) {
-        sessionController.maximumNameLength = 100
 
         let viewModel = ItemTagCreateViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             shopId: shopId
         )
 
@@ -93,7 +86,6 @@ struct ItemTagCreateViewModelTest {
         let viewModel = ItemTagCreateViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             shopId: shopId
         )
 
@@ -104,19 +96,17 @@ struct ItemTagCreateViewModelTest {
 
     @Test
     func validateNameLengthTruncatesCorrectly() {
-        sessionController.maximumNameLength = 4
 
         let viewModel = ItemTagCreateViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             shopId: shopId
         )
 
-        viewModel.name = "abcdefgh"
+        viewModel.name = String(repeating: "a", count: 100) + "EXTRA"
         viewModel.validateNameLength()
 
-        #expect(viewModel.name == "abcd")
+        #expect(viewModel.name == String(repeating: "a", count: 100))
     }
 
     @Test
@@ -124,7 +114,6 @@ struct ItemTagCreateViewModelTest {
         let viewModel = ItemTagCreateViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             shopId: shopId
         )
 
@@ -139,7 +128,6 @@ struct ItemTagCreateViewModelTest {
         let viewModel = ItemTagCreateViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             shopId: shopId
         )
 
@@ -169,7 +157,6 @@ struct ItemTagCreateViewModelTest {
         let viewModel = ItemTagCreateViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             shopId: shopId
         )
 
@@ -192,7 +179,6 @@ struct ItemTagCreateViewModelTest {
         let viewModel = ItemTagCreateViewModel(
             itemTagRepository: itemTagRepository,
             messageBus: messageBus,
-            sessionController: sessionController,
             shopId: shopId
         )
 


### PR DESCRIPTION
## Summary
Ports [nativeapptemplate/NativeAppTemplate-iOS#59](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/59). Two-step cleanup of \`maximumNameLength\` now that the server no longer sends \`maximum_name_length\` in the \`/shopkeeper/permissions\` meta.

### Changes

**Step 1 — Stop reading \`maximum_name_length\` from /shopkeeper/permissions.** The client already tolerated its absence via a \`?? 100\` fallback, so this is dead plumbing. Drops the field from \`PermissionsResponse\`, the meta read in \`PermissionsRequest.handle\`, and the assignment in \`SessionController.fetchPermissions\`.

**Step 2 — Move \`maximumNameLength\` from \`SessionController\` to \`Constants\`.** Now that it's a fixed value, it's just a constant — like \`maximumItemTagDescriptionLength\`. Adds \`NativeAppTemplateConstants.maximumItemTagNameLength = 100\`, drops \`maximumNameLength\` from \`SessionControllerProtocol\` / \`SessionController\` / \`NullSessionController\` / \`TestSessionController\`. \`ItemTagCreateViewModel\` and \`ItemTagEditViewModel\` now read the constant directly and no longer take \`sessionController\` (it had no other use in those view models). Updates the two call sites in \`ItemTagListView\` / \`ItemTagDetailView\`. Tests rewritten: drop \`sessionController\` field, remove all \`sessionController.maximumNameLength = N\` overrides, and update the two truncation tests to use 100+ char strings against the constant.

## Test plan
- [x] \`xcodebuild build-for-testing\` — \`** TEST BUILD SUCCEEDED **\`
- [x] \`make lint\` — \`0 violations\` (SwiftLint + SwiftFormat)
- [ ] \`xcodebuild test\` passes (please verify in Xcode with Cmd+U). Updated \`ItemTagCreateViewModelTest\` and \`ItemTagEditViewModelTest\` should pass — particularly \`maximumNameLength\`, \`nameValidation\`, and \`validateNameLengthTruncatesCorrectly\`.
- [ ] Manual: create / edit an ItemTag — name field should still cap at 100 characters; help text should still display "max 100".

🤖 Generated with [Claude Code](https://claude.com/claude-code)