### PR TITLE
Drop unused tags-scanned count and howToUse; tighten ItemTag labels

### DIFF
--- a/NativeAppTemplate/Constants.swift
+++ b/NativeAppTemplate/Constants.swift
@@ -166,6 +166,7 @@ extension String {
     static let createShopsLabel = "Create shops"
     static let tapShopBelow = "Tap a shop below."
     static let haveFun = "Have fun!"
+    static let shopDetailInstruction = "Swipe an item tag to change its status."
 
     // MARK: Shop Settings View
 
@@ -178,11 +179,11 @@ extension String {
     static let nameLabel = "Name"
     static let descriptionLabel = "Description"
     static let itemTagNamePlaceholder = "Name"
-    static let editTag = "Edit Tag"
-    static let addTag = "Add Tag"
-    static let addTagDescription = "Add a new item tag and start changing the tag status."
-    static let deleteTag = "Delete tag"
-    static let buttonDeleteTag = "Delete Tag"
+    static let editItemTag = "Edit Item Tag"
+    static let addItemTag = "Add Item Tag"
+    static let addItemTagDescription = "Add a new item tag and start changing the item tag status."
+    static let deleteItemTag = "Delete item tag"
+    static let buttonDeleteItemTag = "Delete Item Tag"
     static let itemTagNameIsInvalid = "Item tag name is invalid."
     static let itemTagDescriptionIsInvalid = "Item tag description is too long."
     static let completedAtLabel = "Completed at"
@@ -201,7 +202,6 @@ extension String {
 
     static let supportMail: String = "support@nativeapptemplate.com"
     static let supportWebsiteUrl: String = "https://nativeapptemplate.com"
-    static let howToUseUrl: String = "https://myturntag.com/how"
     static let faqsUrl: String = "https://nativeapptemplate.com/faqs"
     static let privacyPolicyUrl: String = "https://nativeapptemplate.com/privacy"
     static let termsOfUseUrl: String = "https://nativeapptemplate.com/terms"
@@ -235,12 +235,12 @@ extension String {
     static let shopDeleted = "Shop deleted successfully."
     static let shopDeletedError = "There was a problem deleting the shop."
 
-    static let itemTagCreated = "Tag created successfully."
-    static let itemTagUpdated = "Tag updated successfully."
-    static let itemTagDeleted = "Tag deleted successfully."
-    static let itemTagDeletedError = "There was a problem deleting the tag."
-    static let itemTagCompletedError = "There was a problem completing the tag."
-    static let itemTagIdledError = "There was a problem idling the tag."
+    static let itemTagCreated = "Item tag created successfully."
+    static let itemTagUpdated = "Item tag updated successfully."
+    static let itemTagDeleted = "Item tag deleted successfully."
+    static let itemTagDeletedError = "There was a problem deleting the item tag."
+    static let itemTagCompletedError = "There was a problem completing the item tag."
+    static let itemTagIdledError = "There was a problem idling the item tag."
 
     static let shopkeeperCreated = "Account created successfully."
     static let shopkeeperCreatedError = "There was a problem creating the account."
@@ -285,19 +285,14 @@ extension String {
     static let email = "Email"
     static let password = "Password"
 
-    static let onboardingDescription1 = String(localized: "Welcome to NativeAppTemplate.")
-    static let onboardingDescription2 = String(localized: "Sign in to manage your shops and item tags.")
-    static let onboardingDescription3 = String(localized: "Organize your work across multiple organizations.")
-    static let onboardingDescription4 = String(localized: "Invite teammates to collaborate.")
-    static let onboardingDescription5 = String(localized: "Track item tags with a simple idle/completed state.")
-    static let onboardingDescription6 = String(localized: "Create, edit, and delete item tags from your shop.")
-    static let onboardingDescription7 = String(localized: "Switch between personal and shared organizations.")
-    static let onboardingDescription8 = String(localized: "Have fun!")
-    static let onboardingDescription9 = String(localized: "Have fun!")
-    static let onboardingDescription10 = String(localized: "Have fun!")
-    static let onboardingDescription11 = String(localized: "Have fun!")
-    static let onboardingDescription12 = String(localized: "Have fun!")
-    static let onboardingDescription13 = String(localized: "Have fun!")
+    static let onboardingDescription1 = "Welcome to NativeAppTemplate."
+    static let onboardingDescription2 = "Sign in to manage your shops and item tags."
+    static let onboardingDescription3 = "Organize your work across multiple organizations."
+    static let onboardingDescription4 = "Invite teammates to collaborate."
+    static let onboardingDescription5 = "Track item tags with a simple idle/completed state."
+    static let onboardingDescription6 = "Create, edit, and delete item tags from your shop."
+    static let onboardingDescription7 = "Switch between personal and shared organizations."
+    static let onboardingDescription8 = "Have fun!"
 
     // MARK: Other
 
@@ -320,11 +315,8 @@ extension String {
     static let passwordIsRequired = "Password is required."
     static let passwordIsInvalid = "Password is invalid."
     static let role = "Role"
-    static let createShops = "Create shops."
-    static let createTags = "Create tags."
     static let complete = "Complete"
     static let open = "Open"
-    static let learnMore = "Learn More"
     static let instructions = "Instructions"
     static let forceSignOut = "Force Sign Out?"
     static let signOut = "Sign Out"

--- a/NativeAppTemplate/Login/OnboardingRepository.swift
+++ b/NativeAppTemplate/Login/OnboardingRepository.swift
@@ -16,12 +16,7 @@ import OrderedCollections
         5: false,
         6: false,
         7: true,
-        8: true,
-        9: false,
-        10: false,
-        11: true,
-        12: false,
-        13: false
+        8: true
     ]
 
     func reload() {

--- a/NativeAppTemplate/Models/Shop.swift
+++ b/NativeAppTemplate/Models/Shop.swift
@@ -11,7 +11,6 @@ struct Shop: Codable, Identifiable, Sendable {
     var description: String
     var timeZone: String
     var itemTagsCount: Int = 0
-    var scannedItemTagsCount: Int = 0
     var completedItemTagsCount: Int = 0
 }
 

--- a/NativeAppTemplate/Networking/Adapters/EntityAdapters/ShopAdapter.swift
+++ b/NativeAppTemplate/Networking/Adapters/EntityAdapters/ShopAdapter.swift
@@ -25,7 +25,6 @@ struct ShopAdapter: EntityAdapter {
             description: resource.attributes["description"] as? String ?? "",
             timeZone: timeZone,
             itemTagsCount: resource.attributes["item_tags_count"] as? Int ?? 0,
-            scannedItemTagsCount: resource.attributes["scanned_item_tags_count"] as? Int ?? 0,
             completedItemTagsCount: resource.attributes["completed_item_tags_count"] as? Int ?? 0
         )
     }

--- a/NativeAppTemplate/UI/App Root/OnboardingView.swift
+++ b/NativeAppTemplate/UI/App Root/OnboardingView.swift
@@ -6,7 +6,6 @@
 import SwiftUI
 
 struct OnboardingView: View {
-    let isAppStorePromotion = false
     @State private var viewModel: OnboardingViewModel
 
     init(onboardingRepository: OnboardingRepositoryProtocol) {
@@ -39,17 +38,15 @@ private extension OnboardingView {
                         )
                     }
                 }
-                .tabViewStyle(.page(indexDisplayMode: isAppStorePromotion ? .never : .always))
+                .tabViewStyle(.page(indexDisplayMode: .always))
                 .toolbar {
-                    if !isAppStorePromotion {
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            Link(String.howToUse, destination: URL(string: String.howToUseUrl)!)
-                        }
-                        ToolbarItem(placement: .navigationBarTrailing) {
-                            NavigationLink(destination: SignUpOrSignInView()) {
-                                Text(verbatim: "Start")
-                                    .font(.title)
-                            }
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Link(String.supportWebsite, destination: URL(string: String.supportWebsiteUrl)!)
+                    }
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        NavigationLink(destination: SignUpOrSignInView()) {
+                            Text(verbatim: "Start")
+                                .font(.title)
                         }
                     }
                 }

--- a/NativeAppTemplate/UI/App Root/OnboardingViewModel.swift
+++ b/NativeAppTemplate/UI/App Root/OnboardingViewModel.swift
@@ -40,16 +40,6 @@ final class OnboardingViewModel {
             String.onboardingDescription7
         case 8:
             String.onboardingDescription8
-        case 9:
-            String.onboardingDescription9
-        case 10:
-            String.onboardingDescription10
-        case 11:
-            String.onboardingDescription11
-        case 12:
-            String.onboardingDescription12
-        case 13:
-            String.onboardingDescription13
         default:
             String.onboardingDescription1
         }

--- a/NativeAppTemplate/UI/Shop Detail/ShopDetailView.swift
+++ b/NativeAppTemplate/UI/Shop Detail/ShopDetailView.swift
@@ -51,11 +51,10 @@ private extension ShopDetailView {
     }
 
     func header(shop: Shop) -> some View {
-        ScrollView(.horizontal) {
-            VStack(alignment: .leading, spacing: 0) {
-                Link(String.learnMore, destination: URL(string: String.howToUseUrl)!)
-            }
-        }
+        Text(String.shopDetailInstruction)
+            .foregroundStyle(.contentText)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading)
     }
 
     var cardsView: some View {

--- a/NativeAppTemplate/UI/Shop List/ShopListCardView.swift
+++ b/NativeAppTemplate/UI/Shop List/ShopListCardView.swift
@@ -22,18 +22,6 @@ struct ShopListCardView: View {
                 verticalSpacing: NativeAppTemplateConstants.Spacing.xxxs
             ) {
                 GridRow {
-                    Image(systemName: "person.2")
-                        .frame(width: statImageSize, height: statImageSize)
-                        .foregroundStyle(.secondaryText)
-                    Text(String(shop.scannedItemTagsCount))
-                        .font(.uiLabelBold)
-                        .gridColumnAlignment(.trailing)
-                    Text(verbatim: "tags scanned by customers")
-                        .font(.uiFootnote)
-                        .foregroundStyle(.contentText)
-                }
-
-                GridRow {
                     Image(systemName: "flag.checkered")
                         .frame(width: statImageSize, height: statImageSize)
                         .foregroundStyle(.secondaryText)

--- a/NativeAppTemplate/UI/Shop Settings/ItemTag Detail/ItemTagDetailView.swift
+++ b/NativeAppTemplate/UI/Shop Settings/ItemTag Detail/ItemTagDetailView.swift
@@ -67,10 +67,10 @@ private extension ItemTagDetailView {
             }
         )
         .alert(
-            String.buttonDeleteTag,
+            String.buttonDeleteItemTag,
             isPresented: $viewModel.isShowingDeleteConfirmationDialog
         ) {
-            Button(String.buttonDeleteTag, role: .destructive) {
+            Button(String.buttonDeleteItemTag, role: .destructive) {
                 viewModel.destroyItemTag()
             }
             Button(String.cancel, role: .cancel) {

--- a/NativeAppTemplate/UI/Shop Settings/ItemTag Detail/ItemTagEditView.swift
+++ b/NativeAppTemplate/UI/Shop Settings/ItemTag Detail/ItemTagEditView.swift
@@ -79,7 +79,7 @@ private extension ItemTagEditView {
                     }
                 }
             }
-            .navigationTitle(String.editTag)
+            .navigationTitle(String.editItemTag)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {

--- a/NativeAppTemplate/UI/Shop Settings/ItemTag List/ItemTagCreateView.swift
+++ b/NativeAppTemplate/UI/Shop Settings/ItemTag List/ItemTagCreateView.swift
@@ -76,7 +76,7 @@ private extension ItemTagCreateView {
                     }
                 }
             }
-            .navigationTitle(String.addTag)
+            .navigationTitle(String.addItemTag)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {

--- a/NativeAppTemplate/UI/Shop Settings/ItemTag List/ItemTagListView.swift
+++ b/NativeAppTemplate/UI/Shop Settings/ItemTag List/ItemTagListView.swift
@@ -138,12 +138,11 @@ private extension ItemTagListView {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: NativeAppTemplateConstants.Spacing.xxxl)
                 .padding()
-
-            Text(String.addTagDescription)
+            Text(String.addItemTagDescription)
                 .foregroundStyle(.contentText)
                 .padding()
 
-            MainButtonView(title: String.addTag, type: .primary(withArrow: false)) {
+            MainButtonView(title: String.addItemTag, type: .primary(withArrow: false)) {
                 viewModel.isShowingCreateSheet.toggle()
             }
             .padding()

--- a/NativeAppTemplateTests/Demo/Data/Repositories/DemoShopRepository.swift
+++ b/NativeAppTemplateTests/Demo/Data/Repositories/DemoShopRepository.swift
@@ -67,7 +67,6 @@ final class DemoShopRepository: ShopRepositoryProtocol {
             description: "This is a mock shop for testing",
             timeZone: "Tokyo",
             itemTagsCount: 10,
-            scannedItemTagsCount: 5,
             completedItemTagsCount: 3
         )
     }

--- a/NativeAppTemplateTests/Demo/Data/Repositories/DemoShopRepositoryTest.swift
+++ b/NativeAppTemplateTests/Demo/Data/Repositories/DemoShopRepositoryTest.swift
@@ -47,7 +47,6 @@ struct DemoShopRepositoryTest {
                 description: "A new shop",
                 timeZone: "Tokyo",
                 itemTagsCount: 0,
-                scannedItemTagsCount: 0,
                 completedItemTagsCount: 0
             )
 

--- a/NativeAppTemplateTests/UI/App Root/OnboardingViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/App Root/OnboardingViewModelTest.swift
@@ -96,7 +96,7 @@ struct OnboardingViewModelTest {
 
     @Test
     func onboardingDescriptionAllSteps() {
-        let onboardings = (1...13).map { mockOnboarding(id: $0) }
+        let onboardings = (1...8).map { mockOnboarding(id: $0) }
         onboardingRepository.setOnboardings(onboardings: onboardings)
 
         let viewModel = OnboardingViewModel(
@@ -105,16 +105,13 @@ struct OnboardingViewModelTest {
 
         viewModel.reload()
 
-        // Test all 13 onboarding steps (1-based indexing)
         let expectedDescriptions = [
             String.onboardingDescription1, String.onboardingDescription2, String.onboardingDescription3,
             String.onboardingDescription4, String.onboardingDescription5, String.onboardingDescription6,
-            String.onboardingDescription7, String.onboardingDescription8, String.onboardingDescription9,
-            String.onboardingDescription10, String.onboardingDescription11, String.onboardingDescription12,
-            String.onboardingDescription13
+            String.onboardingDescription7, String.onboardingDescription8
         ]
 
-        for index in 1...13 {
+        for index in 1...8 {
             #expect(viewModel.onboardingDescription(index: index) == expectedDescriptions[index - 1])
         }
     }

--- a/NativeAppTemplateTests/UI/Shop Detail/ShopDetailViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Detail/ShopDetailViewModelTest.swift
@@ -290,7 +290,6 @@ struct ShopDetailViewModelTest { // swiftlint:disable:this type_body_length
             description: "This is a mock shop for testing",
             timeZone: "Tokyo",
             itemTagsCount: 10,
-            scannedItemTagsCount: 5,
             completedItemTagsCount: 3
         )
     }

--- a/NativeAppTemplateTests/UI/Shop List/ShopListViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop List/ShopListViewModelTest.swift
@@ -193,7 +193,6 @@ struct ShopListViewModelTest {
             description: "This is a mock shop for testing",
             timeZone: "Tokyo",
             itemTagsCount: 10,
-            scannedItemTagsCount: 5,
             completedItemTagsCount: 3
         )
     }

--- a/NativeAppTemplateTests/UI/Shop Settings/ItemTag Detail/ItemTagDetailViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Settings/ItemTag Detail/ItemTagDetailViewModelTest.swift
@@ -383,7 +383,6 @@ struct ItemTagDetailViewModelTest {
             description: "This is a mock shop for testing",
             timeZone: "Tokyo",
             itemTagsCount: 10,
-            scannedItemTagsCount: 5,
             completedItemTagsCount: 3
         )
     }

--- a/NativeAppTemplateTests/UI/Shop Settings/ItemTag List/ItemTagListViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Settings/ItemTag List/ItemTagListViewModelTest.swift
@@ -340,7 +340,6 @@ struct ItemTagListViewModelTest {
             description: "This is a mock shop for testing",
             timeZone: "Tokyo",
             itemTagsCount: 10,
-            scannedItemTagsCount: 5,
             completedItemTagsCount: 3
         )
     }

--- a/NativeAppTemplateTests/UI/Shop Settings/ShopBasicSettingsViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Settings/ShopBasicSettingsViewModelTest.swift
@@ -348,7 +348,6 @@ struct ShopBasicSettingsViewModelTest {
             description: "This is a mock shop for testing",
             timeZone: "Tokyo",
             itemTagsCount: 10,
-            scannedItemTagsCount: 5,
             completedItemTagsCount: 3
         )
     }

--- a/NativeAppTemplateTests/UI/Shop Settings/ShopSettingsViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Settings/ShopSettingsViewModelTest.swift
@@ -181,7 +181,6 @@ struct ShopSettingsViewModelTest {
             description: "This is a mock shop for testing",
             timeZone: "Tokyo",
             itemTagsCount: 10,
-            scannedItemTagsCount: 5,
             completedItemTagsCount: 3
         )
     }


### PR DESCRIPTION
## Summary
- Drop `scannedItemTagsCount` from `Shop` model, adapter, demo repo, and tests; remove the "tags scanned by customers" stat from `ShopListCardView`.
- Replace `ShopDetailView` "Learn More" link with a left-aligned `shopDetailInstruction` ("Swipe an item tag to change its status.").
- Swap the `OnboardingView` "How to use" link for the Support Website link; trim onboarding from 13 to 8 descriptions and drop unused `String(localized:)` wrap.
- Normalize ItemTag string keys: `editTag`/`addTag`/`deleteTag`/etc. → `editItemTag`/`addItemTag`/`deleteItemTag`/etc.
- Drop unused constants: `howToUseUrl`, `learnMore`, `createShops`, `createTags`.

Ports https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/61.

## Test plan
- [x] `make lint` passes
- [x] Build & run; verify `ShopDetailView` shows the new instruction text, left-aligned
- [x] Verify Onboarding shows the Support Website link in the toolbar and 8 description pages
- [x] Verify `ShopListCardView` no longer shows the scanned tags row
- [x] Verify ItemTag create/edit/delete labels read "Item Tag" everywhere
- [x] Run unit tests in Xcode (Cmd+U)