### PR TITLE
Drop onboarding reload ceremony

### DIFF
--- a/NativeAppTemplate/Login/OnboardingRepository.swift
+++ b/NativeAppTemplate/Login/OnboardingRepository.swift
@@ -12,6 +12,4 @@ import Foundation
         Onboarding(id: 3, imageOrientation: .portrait),
         Onboarding(id: 4, imageOrientation: .portrait)
     ]
-
-    func reload() {}
 }

--- a/NativeAppTemplate/Login/OnboardingRepositoryProtocol.swift
+++ b/NativeAppTemplate/Login/OnboardingRepositoryProtocol.swift
@@ -8,6 +8,4 @@ import Foundation
 @MainActor
 protocol OnboardingRepositoryProtocol: AnyObject, Observable, Sendable {
     var onboardings: [Onboarding] { get set }
-
-    func reload()
 }

--- a/NativeAppTemplate/UI/App Root/OnboardingView.swift
+++ b/NativeAppTemplate/UI/App Root/OnboardingView.swift
@@ -15,9 +15,6 @@ struct OnboardingView: View {
     var body: some View {
         NavigationStack {
             contentView
-                .task {
-                    viewModel.reload()
-                }
         }
     }
 }

--- a/NativeAppTemplate/UI/App Root/OnboardingViewModel.swift
+++ b/NativeAppTemplate/UI/App Root/OnboardingViewModel.swift
@@ -9,17 +9,14 @@ import SwiftUI
 @Observable
 @MainActor
 final class OnboardingViewModel {
-    var onboardings: [Onboarding] = []
-
     private let onboardingRepository: OnboardingRepositoryProtocol
+
+    var onboardings: [Onboarding] {
+        onboardingRepository.onboardings
+    }
 
     init(onboardingRepository: OnboardingRepositoryProtocol) {
         self.onboardingRepository = onboardingRepository
-    }
-
-    func reload() {
-        onboardingRepository.reload()
-        onboardings = onboardingRepository.onboardings
     }
 
     func onboardingDescription(index: Int) -> String {

--- a/NativeAppTemplateTests/Demo/Data/Repositories/DemoOnboardingRepository.swift
+++ b/NativeAppTemplateTests/Demo/Data/Repositories/DemoOnboardingRepository.swift
@@ -14,10 +14,6 @@ final class DemoOnboardingRepository: OnboardingRepositoryProtocol {
         setupMockOnboardings()
     }
 
-    func reload() {
-        setupMockOnboardings()
-    }
-
     // MARK: - Test Helpers
 
     func resetState() {

--- a/NativeAppTemplateTests/Demo/Data/Repositories/DemoOnboardingRepositoryTest.swift
+++ b/NativeAppTemplateTests/Demo/Data/Repositories/DemoOnboardingRepositoryTest.swift
@@ -34,18 +34,6 @@ struct DemoOnboardingRepositoryTest {
         }
 
         @Test
-        func reload() {
-            repository.resetState()
-
-            repository.onboardings.removeAll()
-            #expect(repository.onboardings.isEmpty)
-
-            repository.reload()
-
-            #expect(repository.onboardings.count == 5)
-        }
-
-        @Test
         func addOnboarding() throws {
             repository.resetState()
 

--- a/NativeAppTemplateTests/Testing/Repositories/TestOnboardingRepository.swift
+++ b/NativeAppTemplateTests/Testing/Repositories/TestOnboardingRepository.swift
@@ -11,13 +11,6 @@ final class TestOnboardingRepository: OnboardingRepositoryProtocol {
     var onboardings: [Onboarding] = []
 
     /// A test-only
-    var reloadCalled = false
-
-    func reload() {
-        reloadCalled = true
-    }
-
-    /// A test-only
     func setOnboardings(onboardings: [Onboarding]) {
         self.onboardings = onboardings
     }

--- a/NativeAppTemplateTests/UI/App Root/OnboardingViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/App Root/OnboardingViewModelTest.swift
@@ -32,7 +32,7 @@ struct OnboardingViewModelTest {
     }
 
     @Test
-    func reload() {
+    func exposesRepositoryOnboardings() {
         let onboardings = [
             mockOnboarding(id: 1, imageOrientation: .portrait),
             mockOnboarding(id: 2, imageOrientation: .landscape),
@@ -45,90 +45,29 @@ struct OnboardingViewModelTest {
             onboardingRepository: onboardingRepository
         )
 
-        viewModel.reload()
-
-        #expect(onboardingRepository.reloadCalled == true)
         #expect(viewModel.onboardings.count == 3)
     }
 
     @Test
     func onboardingDescription() {
-        let onboardings = [
-            mockOnboarding(id: 1),
-            mockOnboarding(id: 2),
-            mockOnboarding(id: 3)
-        ]
-
-        onboardingRepository.setOnboardings(onboardings: onboardings)
-
         let viewModel = OnboardingViewModel(
             onboardingRepository: onboardingRepository
         )
 
-        viewModel.reload()
-
-        // Test valid indices (1-based indexing in the switch case)
         #expect(viewModel.onboardingDescription(index: 1) == Strings.onboardingDescription1)
         #expect(viewModel.onboardingDescription(index: 2) == Strings.onboardingDescription2)
         #expect(viewModel.onboardingDescription(index: 3) == Strings.onboardingDescription3)
+        #expect(viewModel.onboardingDescription(index: 4) == Strings.onboardingDescription4)
     }
 
     @Test
     func onboardingDescriptionInvalidIndex() {
-        let onboardings = [
-            mockOnboarding(id: 1)
-        ]
-
-        onboardingRepository.setOnboardings(onboardings: onboardings)
-
         let viewModel = OnboardingViewModel(
             onboardingRepository: onboardingRepository
         )
 
-        viewModel.reload()
-
-        // Test invalid indices - should return default (onboardingDescription1)
-        let result = viewModel.onboardingDescription(index: 0)
-        #expect(result == Strings.onboardingDescription1)
-        let result2 = viewModel.onboardingDescription(index: 99)
-        #expect(result2 == Strings.onboardingDescription1)
-    }
-
-    @Test
-    func onboardingDescriptionAllSteps() {
-        let onboardings = (1...4).map { mockOnboarding(id: $0) }
-        onboardingRepository.setOnboardings(onboardings: onboardings)
-
-        let viewModel = OnboardingViewModel(
-            onboardingRepository: onboardingRepository
-        )
-
-        viewModel.reload()
-
-        let expectedDescriptions = [
-            Strings.onboardingDescription1,
-            Strings.onboardingDescription2,
-            Strings.onboardingDescription3,
-            Strings.onboardingDescription4
-        ]
-
-        for index in 1...4 {
-            #expect(viewModel.onboardingDescription(index: index) == expectedDescriptions[index - 1])
-        }
-    }
-
-    @Test
-    func emptyOnboardings() {
-        onboardingRepository.setOnboardings(onboardings: [])
-
-        let viewModel = OnboardingViewModel(
-            onboardingRepository: onboardingRepository
-        )
-
-        viewModel.reload()
-
-        #expect(viewModel.onboardings.isEmpty)
-        #expect(onboardingRepository.reloadCalled == true)
+        #expect(viewModel.onboardingDescription(index: 0) == Strings.onboardingDescription1)
+        #expect(viewModel.onboardingDescription(index: 99) == Strings.onboardingDescription1)
     }
 
     @Test
@@ -145,8 +84,6 @@ struct OnboardingViewModelTest {
         let viewModel = OnboardingViewModel(
             onboardingRepository: onboardingRepository
         )
-
-        viewModel.reload()
 
         #expect(viewModel.onboardings.count == 4)
         #expect(viewModel.onboardings[0].imageOrientation == .portrait)


### PR DESCRIPTION
Mirror of upstream [nativeapptemplate/NativeAppTemplate-iOS#64](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/64).

## Summary
- Drop `reload()` from `OnboardingRepositoryProtocol` and all impls. Onboarding slides are static client-side data, so the reload-then-read indirection through repository → viewModel → view.task was just ceremony.
- Expose `OnboardingViewModel.onboardings` as a computed pass-through to the repository.
- Remove the `.task { viewModel.reload() }` from `OnboardingView`.
- Drop `reloadCalled` instrumentation from `TestOnboardingRepository` and update the corresponding tests.

Net diff: 8 files, +8/-104.

## Test plan
- [x] `make lint` passes
- [x] `xcodebuild ... build-for-testing` succeeds (iPhone 17, iOS 26.4.1)
- [ ] Run tests in Xcode (Cmd+U)
- [ ] Launch app and confirm onboarding still renders 4 slides correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)