### PR TITLE
Add unit tests for untested Models and Date extension

### DIFF
--- a/NativeAppTemplateTests/Extensions/DateExtensionsTest.swift
+++ b/NativeAppTemplateTests/Extensions/DateExtensionsTest.swift
@@ -1,0 +1,58 @@
+//
+//  DateExtensionsTest.swift
+//  NativeAppTemplate
+//
+
+import Foundation
+@testable import NativeAppTemplate
+import Testing
+
+struct DateExtensionsTest {
+    private func date(_ iso: String) throws -> Date {
+        try #require(iso.iso8601)
+    }
+
+    @Test
+    func dateByAddingNumberOfSecondsAddsPositiveSeconds() throws {
+        let date = try date("2026-01-01T00:00:00.000Z")
+        let later = date.dateByAddingNumberOfSeconds(3600)
+        #expect(later.timeIntervalSince(date) == 3600)
+    }
+
+    @Test
+    func dateByAddingNumberOfSecondsAcceptsNegative() throws {
+        let date = try date("2026-01-01T00:00:00.000Z")
+        let earlier = date.dateByAddingNumberOfSeconds(-60)
+        #expect(earlier.timeIntervalSince(date) == -60)
+    }
+
+    @Test
+    func cardDateStringFormatsAsYearMonthDay() throws {
+        let date = try date("2026-04-29T12:34:56.000Z")
+        let formatted = date.cardDateString
+        // Output is locale-fixed (en_US_POSIX) but uses the device's current
+        // time zone, so we just assert the format shape.
+        #expect(formatted.count == 10)
+        #expect(formatted.contains("/"))
+        let parts = formatted.split(separator: "/")
+        #expect(parts.count == 3)
+        #expect(parts[0].count == 4) // year
+        #expect(parts[1].count == 2) // month
+        #expect(parts[2].count == 2) // day
+    }
+
+    @Test
+    func cardTimeStringFormatsAsHourMinute() throws {
+        let date = try date("2026-04-29T12:34:56.000Z")
+        let formatted = date.cardTimeString
+        #expect(formatted.count == 5)
+        #expect(formatted[formatted.index(formatted.startIndex, offsetBy: 2)] == ":")
+    }
+
+    @Test
+    func cardDateTimeStringConcatenatesDateAndTime() throws {
+        let date = try date("2026-04-29T12:34:56.000Z")
+        let combined = date.cardDateTimeString
+        #expect(combined == "\(date.cardDateString) \(date.cardTimeString)")
+    }
+}

--- a/NativeAppTemplateTests/Models/ItemTagTest.swift
+++ b/NativeAppTemplateTests/Models/ItemTagTest.swift
@@ -1,0 +1,50 @@
+//
+//  ItemTagTest.swift
+//  NativeAppTemplate
+//
+
+@testable import NativeAppTemplate
+import Testing
+
+struct ItemTagTest {
+    @Test
+    func toJsonWrapsFieldsUnderItemTagKey() throws {
+        var itemTag = ItemTag()
+        itemTag.name = "Table 1"
+        itemTag.description = "Window seat"
+
+        let json = itemTag.toJson()
+        let inner = try #require(json["item_tag"] as? [String: Any])
+
+        #expect(inner["name"] as? String == "Table 1")
+        #expect(inner["description"] as? String == "Window seat")
+    }
+
+    @Test
+    func toJsonOnlyIncludesNameAndDescription() throws {
+        var itemTag = ItemTag()
+        itemTag.id = "abc-123"
+        itemTag.shopId = "shop-1"
+        itemTag.name = "n"
+        itemTag.description = "d"
+        itemTag.position = 5
+        itemTag.shopName = "Cafe"
+
+        let json = itemTag.toJson()
+        let inner = try #require(json["item_tag"] as? [String: Any])
+
+        #expect(inner.keys.sorted() == ["description", "name"])
+    }
+
+    @Test
+    func defaultsAreEmptyAndIdled() {
+        let itemTag = ItemTag()
+        #expect(itemTag.id.isEmpty)
+        #expect(itemTag.shopId.isEmpty)
+        #expect(itemTag.name.isEmpty)
+        #expect(itemTag.description.isEmpty)
+        #expect(itemTag.position == 0)
+        #expect(itemTag.state == .idled)
+        #expect(itemTag.completedAt == nil)
+    }
+}

--- a/NativeAppTemplateTests/Models/SendConfirmationTest.swift
+++ b/NativeAppTemplateTests/Models/SendConfirmationTest.swift
@@ -1,0 +1,32 @@
+//
+//  SendConfirmationTest.swift
+//  NativeAppTemplate
+//
+
+@testable import NativeAppTemplate
+import Testing
+
+struct SendConfirmationTest {
+    @Test
+    func toJsonIncludesEmailAndRedirectUrl() {
+        let send = SendConfirmation(email: "alice@example.com")
+
+        let json = send.toJson()
+
+        #expect(json["email"] as? String == "alice@example.com")
+        #expect(json["redirect_url"] as? String == send.redirectUrl)
+        #expect(json.keys.sorted() == ["email", "redirect_url"])
+    }
+
+    @Test
+    func defaultRedirectUrlPointsToConfirmationResult() {
+        let send = SendConfirmation(email: "x")
+        #expect(send.redirectUrl.hasSuffix("/shopkeeper_auth/confirmation_result"))
+    }
+
+    @Test
+    func redirectUrlCanBeOverridden() {
+        let send = SendConfirmation(email: "x", redirectUrl: "https://custom.example/cb")
+        #expect(send.toJson()["redirect_url"] as? String == "https://custom.example/cb")
+    }
+}

--- a/NativeAppTemplateTests/Models/SendResetPasswordTest.swift
+++ b/NativeAppTemplateTests/Models/SendResetPasswordTest.swift
@@ -1,0 +1,32 @@
+//
+//  SendResetPasswordTest.swift
+//  NativeAppTemplate
+//
+
+@testable import NativeAppTemplate
+import Testing
+
+struct SendResetPasswordTest {
+    @Test
+    func toJsonIncludesEmailAndRedirectUrl() {
+        let send = SendResetPassword(email: "alice@example.com")
+
+        let json = send.toJson()
+
+        #expect(json["email"] as? String == "alice@example.com")
+        #expect(json["redirect_url"] as? String == send.redirectUrl)
+        #expect(json.keys.sorted() == ["email", "redirect_url"])
+    }
+
+    @Test
+    func defaultRedirectUrlPointsToResetPasswordEdit() {
+        let send = SendResetPassword(email: "x")
+        #expect(send.redirectUrl.hasSuffix("/shopkeeper_auth/reset_password/edit"))
+    }
+
+    @Test
+    func redirectUrlCanBeOverridden() {
+        let send = SendResetPassword(email: "x", redirectUrl: "https://custom.example/cb")
+        #expect(send.toJson()["redirect_url"] as? String == "https://custom.example/cb")
+    }
+}

--- a/NativeAppTemplateTests/Models/ShopTest.swift
+++ b/NativeAppTemplateTests/Models/ShopTest.swift
@@ -1,0 +1,60 @@
+//
+//  ShopTest.swift
+//  NativeAppTemplate
+//
+
+@testable import NativeAppTemplate
+import Testing
+
+struct ShopTest {
+    private func makeShop() -> Shop {
+        Shop(
+            id: "shop-1",
+            name: "Cafe",
+            description: "A nice cafe",
+            timeZone: "Asia/Tokyo"
+        )
+    }
+
+    @Test
+    func toJsonForCreateWrapsFieldsUnderShopKey() throws {
+        let shop = makeShop()
+
+        let json = shop.toJsonForCreate()
+        let inner = try #require(json["shop"] as? [String: Any])
+
+        #expect(inner["name"] as? String == "Cafe")
+        #expect(inner["description"] as? String == "A nice cafe")
+        #expect(inner["time_zone"] as? String == "Asia/Tokyo")
+    }
+
+    @Test
+    func toJsonForCreateExcludesIdAndCounts() throws {
+        let shop = makeShop()
+        let inner = try #require(shop.toJsonForCreate()["shop"] as? [String: Any])
+
+        #expect(inner["id"] == nil)
+        #expect(inner["item_tags_count"] == nil)
+        #expect(inner["completed_item_tags_count"] == nil)
+        #expect(inner.keys.sorted() == ["description", "name", "time_zone"])
+    }
+
+    @Test
+    func toJsonForUpdateMatchesCreateShape() throws {
+        let shop = makeShop()
+        let create = try #require(shop.toJsonForCreate()["shop"] as? [String: Any])
+        let update = try #require(shop.toJsonForUpdate()["shop"] as? [String: Any])
+
+        #expect(create.keys.sorted() == update.keys.sorted())
+        #expect(create["name"] as? String == update["name"] as? String)
+        #expect(create["description"] as? String == update["description"] as? String)
+        #expect(create["time_zone"] as? String == update["time_zone"] as? String)
+    }
+
+    @Test
+    func defaultCountsAreZero() {
+        let shop = makeShop()
+        #expect(shop.itemTagsCount == 0)
+        #expect(shop.completedItemTagsCount == 0)
+    }
+}

--- a/NativeAppTemplateTests/Models/SignUpTest.swift
+++ b/NativeAppTemplateTests/Models/SignUpTest.swift
@@ -1,0 +1,52 @@
+//
+//  SignUpTest.swift
+//  NativeAppTemplate
+//
+
+@testable import NativeAppTemplate
+import Testing
+
+struct SignUpTest {
+    @Test
+    func toJsonForCreateIncludesPasswordAndDefaultsPlatformToIos() {
+        let signUp = SignUp(
+            name: "Alice",
+            email: "alice@example.com",
+            timeZone: "Asia/Tokyo",
+            password: "secret123"
+        )
+
+        let json = signUp.toJsonForCreate()
+
+        #expect(json["name"] as? String == "Alice")
+        #expect(json["email"] as? String == "alice@example.com")
+        #expect(json["time_zone"] as? String == "Asia/Tokyo")
+        #expect(json["current_platform"] as? String == "ios")
+        #expect(json["password"] as? String == "secret123")
+    }
+
+    @Test
+    func toJsonForUpdateExcludesPasswordAndPlatform() {
+        let signUp = SignUp(
+            name: "Alice",
+            email: "alice@example.com",
+            timeZone: "Asia/Tokyo",
+            password: "secret123"
+        )
+
+        let json = signUp.toJsonForUpdate()
+
+        #expect(json["name"] as? String == "Alice")
+        #expect(json["email"] as? String == "alice@example.com")
+        #expect(json["time_zone"] as? String == "Asia/Tokyo")
+        #expect(json["password"] == nil)
+        #expect(json["current_platform"] == nil)
+        #expect(json.keys.sorted() == ["email", "name", "time_zone"])
+    }
+
+    @Test
+    func currentPlatformDefaultsToIos() {
+        let signUp = SignUp(name: "n", email: "e", timeZone: "tz")
+        #expect(signUp.currentPlatform == "ios")
+    }
+}

--- a/NativeAppTemplateTests/Models/UpdatePasswordTest.swift
+++ b/NativeAppTemplateTests/Models/UpdatePasswordTest.swift
@@ -1,0 +1,37 @@
+//
+//  UpdatePasswordTest.swift
+//  NativeAppTemplate
+//
+
+@testable import NativeAppTemplate
+import Testing
+
+struct UpdatePasswordTest {
+    @Test
+    func toJsonWrapsFieldsUnderShopkeeperKey() throws {
+        let update = UpdatePassword(
+            currentPassword: "old-pw",
+            password: "new-pw",
+            passwordConfirmation: "new-pw"
+        )
+
+        let json = update.toJson()
+        let inner = try #require(json["shopkeeper"] as? [String: Any])
+
+        #expect(inner["current_password"] as? String == "old-pw")
+        #expect(inner["password"] as? String == "new-pw")
+        #expect(inner["password_confirmation"] as? String == "new-pw")
+    }
+
+    @Test
+    func toJsonOnlyIncludesPasswordFields() throws {
+        let update = UpdatePassword(
+            currentPassword: "a",
+            password: "b",
+            passwordConfirmation: "c"
+        )
+        let inner = try #require(update.toJson()["shopkeeper"] as? [String: Any])
+
+        #expect(inner.keys.sorted() == ["current_password", "password", "password_confirmation"])
+    }
+}


### PR DESCRIPTION
Mirror of upstream [nativeapptemplate/NativeAppTemplate-iOS#65](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/65), adapted to this fork.

## Summary
Adds unit tests for production code that had no coverage. Targets pure-logic value types and serialization helpers — easy wins, no mocks required.

New test files:
- `NativeAppTemplateTests/Models/ItemTagTest.swift` — `toJson()` shape and default state
- `NativeAppTemplateTests/Models/ShopTest.swift` — `toJsonForCreate` / `toJsonForUpdate`
- `NativeAppTemplateTests/Models/SignUpTest.swift` — create vs. update payloads, platform default
- `NativeAppTemplateTests/Models/UpdatePasswordTest.swift` — `toJson()` shape
- `NativeAppTemplateTests/Models/SendConfirmationTest.swift` — `toJson()` + default redirect URL
- `NativeAppTemplateTests/Models/SendResetPasswordTest.swift` — `toJson()` + default redirect URL
- `NativeAppTemplateTests/Extensions/DateExtensionsTest.swift` — `dateByAddingNumberOfSeconds` + locale-stable shape assertions for `cardDateString` / `cardTimeString` / `cardDateTimeString`

321 new test lines, no production changes.

**Note:** Skipped `PermissionTest.swift` from the upstream PR — this fork does not have a `Permission` model.

## Test plan
- [x] `make lint` passes
- [x] `xcodebuild ... build-for-testing` succeeds (iPhone 17, iOS 26.4.1)
- [ ] Run tests in Xcode (Cmd+U)

🤖 Generated with [Claude Code](https://claude.com/claude-code)