### PR TITLE
README: drop stale NFC/QR feature lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,10 @@ NativeAppTemplate-Free-iOS uses modern iOS development tools and practices, incl
 - Email Confirmation
 - Forgot Password
 - CRUD Operations for Shops (Create/Read/Update/Delete)
-- CRUD Operations for Shops' Nested Resource, Number Tags (ItemTags) (Create/Read/Update/Delete)
+- CRUD Operations for Shops' Nested Resource, Item Tags (Create/Read/Update/Delete)
 - Force App Version Update
 - Force Privacy Policy Version Update
 - Force Terms of Use Version Update
-- Generate QR Code Image for Number Tags (ItemTags) with a Centered Number
-- NFC features for Number Tags (ItemTags): Write Application Info to a Tag, Read a Tag, Background Tag Reading
 - And more!
 
 ## NFC Tag Operations


### PR DESCRIPTION
Mirror of upstream [nativeapptemplate/NativeAppTemplate-iOS#68](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/68).

## Summary
README still advertised NFC and QR features that were removed in Phase 2A-2.

Changes:
- Drop the "Generate QR Code Image…" line.
- Drop the "NFC features for Number Tags…" line.
- Collapse "Number Tags (ItemTags)" → "Item Tags".

## Test plan
- [x] `git diff` shows only the three intended bullet changes
- [ ] Render README on GitHub once merged to confirm formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)