### PR TITLE
Normalize substrate naming: drop NATI-/NATEMPLATE_API_ abbreviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Pagination support for item tags list
-- CodedError system with `NATI-XXXX` prefixed error codes
+- CodedError system with `NATIVEAPPTEMPLATE-XXXX` prefixed error codes
 - App version display in settings
 - Design system constants (spacing, animation, glass, layout, corner radius)
 - GlassButtonStyle and GlassCard components with glassmorphism styling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,18 +107,17 @@ NativeAppTemplate/
 ```
 
 ### Error Handling (CodedError System)
-All errors use the `CodedError` protocol in `NativeAppTemplate/Common/Errors/`. Error codes use the `NATI-XXXX` prefix (NativeAppTemplate iOS) to distinguish from Android (`NATA-XXXX`).
+All errors use the `CodedError` protocol in `NativeAppTemplate/Common/Errors/`. Error codes share the `NATIVEAPPTEMPLATE-XXXX` prefix across iOS and Android.
 
 | Range | Type | File |
 |-------|------|------|
-| NATI-1xxx | App/general errors | `AppError.swift` |
-| NATI-2xxx | API/network errors | `NativeAppTemplateAPIError.swift` |
-| NATI-3xxx | NFC/scan errors | `NFCError.swift` |
+| NATIVEAPPTEMPLATE-1xxx | App/general errors | `AppError.swift` |
+| NATIVEAPPTEMPLATE-2xxx | API/network errors | `NativeAppTemplateAPIError.swift` |
 
 - New error types must conform to `CodedError` and be placed in `Common/Errors/`
 - Use `error.codedDescription` (not `error.localizedDescription`) in all error messages
 - Use `Message(error: error)` convenience to post errors to `MessageBus`
-- Error code numbers must match across iOS and Android (only the prefix differs)
+- Error code numbers must match across iOS and Android
 
 ### Dependencies (Swift Package Manager)
 - KeychainAccess (4.2.2) - Secure credential storage

--- a/NativeAppTemplate/Common/Errors/AppError.swift
+++ b/NativeAppTemplate/Common/Errors/AppError.swift
@@ -16,7 +16,7 @@ enum AppError: CodedError {
     var errorCode: String {
         switch self {
         case .unexpected:
-            "NATI-1001"
+            "NATIVEAPPTEMPLATE-1001"
         }
     }
 

--- a/NativeAppTemplate/Common/Errors/CodedError.swift
+++ b/NativeAppTemplate/Common/Errors/CodedError.swift
@@ -3,8 +3,7 @@
 //  NativeAppTemplate
 //
 
-// Error codes use the `NATI-XXXX` prefix (NativeAppTemplate iOS).
-// Android uses `NATA-XXXX`.
+// Error codes share the `NATIVEAPPTEMPLATE-XXXX` prefix across iOS and Android.
 // Ranges: 1xxx App errors, 2xxx API errors.
 
 import Foundation

--- a/NativeAppTemplate/Common/Errors/NativeAppTemplateAPIError.swift
+++ b/NativeAppTemplate/Common/Errors/NativeAppTemplateAPIError.swift
@@ -15,15 +15,15 @@ enum NativeAppTemplateAPIError: CodedError {
     nonisolated var errorCode: String {
         switch self {
         case .requestFailed:
-            "NATI-2001"
+            "NATIVEAPPTEMPLATE-2001"
         case .processingError:
-            "NATI-2002"
+            "NATIVEAPPTEMPLATE-2002"
         case .responseMissingRequiredMeta:
-            "NATI-2003"
+            "NATIVEAPPTEMPLATE-2003"
         case .responseHasIncorrectNumberOfElements:
-            "NATI-2004"
+            "NATIVEAPPTEMPLATE-2004"
         case .noData:
-            "NATI-2005"
+            "NATIVEAPPTEMPLATE-2005"
         }
     }
 

--- a/NativeAppTemplate/Constants.swift
+++ b/NativeAppTemplate/Constants.swift
@@ -105,9 +105,9 @@ enum NativeAppTemplateConstants {
 enum Strings {
     #if DEBUG
     private static let env = ProcessInfo.processInfo.environment
-    static let scheme: String = env["NATEMPLATE_API_SCHEME"] ?? "https"
-    static let domain: String = env["NATEMPLATE_API_DOMAIN"] ?? "api.nativeapptemplate.com"
-    static let port: String = env["NATEMPLATE_API_PORT"] ?? ""
+    static let scheme: String = env["NATIVEAPPTEMPLATE_API_SCHEME"] ?? "https"
+    static let domain: String = env["NATIVEAPPTEMPLATE_API_DOMAIN"] ?? "api.nativeapptemplate.com"
+    static let port: String = env["NATIVEAPPTEMPLATE_API_PORT"] ?? ""
     #else
     static let scheme: String = "https"
     static let domain: String = "api.nativeapptemplate.com"

--- a/NativeAppTemplateTests/UI/Shop Detail/ShopDetailViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Detail/ShopDetailViewModelTest.swift
@@ -111,7 +111,7 @@ struct ShopDetailViewModelTest { // swiftlint:disable:this type_body_length
         }
         await reloadTask.value
 
-        #expect(viewModel.messageBus.currentMessage?.message == "[NATI-2001] \(message) [Status: \(httpResponseCode)]")
+        #expect(viewModel.messageBus.currentMessage?.message == "[NATIVEAPPTEMPLATE-2001] \(message) [Status: \(httpResponseCode)]")
         #expect(viewModel.shouldDismiss)
     }
 

--- a/NativeAppTemplateTests/UI/Shop List/ShopCreateViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop List/ShopCreateViewModelTest.swift
@@ -180,7 +180,7 @@ struct ShopCreateViewModelTest {
         }
         await createShopTask.value
 
-        #expect(viewModel.messageBus.currentMessage?.message == "[NATI-2001] \(message) [Status: \(httpResponseCode)]")
+        #expect(viewModel.messageBus.currentMessage?.message == "[NATIVEAPPTEMPLATE-2001] \(message) [Status: \(httpResponseCode)]")
         #expect(viewModel.isCreating)
         #expect(shopRepository.shops.count == createdShopsCount)
         #expect(viewModel.shouldDismiss)
@@ -215,7 +215,7 @@ struct ShopCreateViewModelTest {
         }
         await createShopTask.value
 
-        #expect(viewModel.messageBus.currentMessage?.message == "[NATI-2001] \(message) [Status: \(httpResponseCode)]")
+        #expect(viewModel.messageBus.currentMessage?.message == "[NATIVEAPPTEMPLATE-2001] \(message) [Status: \(httpResponseCode)]")
         #expect(viewModel.isCreating)
         #expect(shopRepository.shops.count == createdShopsCount)
         #expect(viewModel.shouldDismiss == false)

--- a/NativeAppTemplateTests/UI/Shop Settings/ShopBasicSettingsViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Settings/ShopBasicSettingsViewModelTest.swift
@@ -250,7 +250,7 @@ struct ShopBasicSettingsViewModelTest {
         }
         await reloadTask.value
 
-        #expect(viewModel.messageBus.currentMessage?.message == "[NATI-2001] \(message) [Status: \(httpResponseCode)]")
+        #expect(viewModel.messageBus.currentMessage?.message == "[NATIVEAPPTEMPLATE-2001] \(message) [Status: \(httpResponseCode)]")
         #expect(viewModel.shouldDismiss)
     }
 
@@ -335,7 +335,7 @@ struct ShopBasicSettingsViewModelTest {
         }
         await updateShopTask.value
 
-        #expect(viewModel.messageBus.currentMessage?.message == "[NATI-2001] \(message) [Status: \(httpResponseCode)]")
+        #expect(viewModel.messageBus.currentMessage?.message == "[NATIVEAPPTEMPLATE-2001] \(message) [Status: \(httpResponseCode)]")
         #expect(viewModel.isUpdating == false)
         #expect(viewModel.isBusy == false)
         #expect(viewModel.shouldDismiss)

--- a/NativeAppTemplateTests/UI/Shop Settings/ShopSettingsViewModelTest.swift
+++ b/NativeAppTemplateTests/UI/Shop Settings/ShopSettingsViewModelTest.swift
@@ -96,7 +96,7 @@ struct ShopSettingsViewModelTest {
         }
         await reloadTask.value
 
-        #expect(viewModel.messageBus.currentMessage?.message == "[NATI-2001] \(message) [Status: \(httpResponseCode)]")
+        #expect(viewModel.messageBus.currentMessage?.message == "[NATIVEAPPTEMPLATE-2001] \(message) [Status: \(httpResponseCode)]")
         #expect(viewModel.shouldDismiss)
         #expect(viewModel.isFetching == false)
         #expect(viewModel.isBusy == false)
@@ -168,7 +168,7 @@ struct ShopSettingsViewModelTest {
         await destroyShopTask.value
 
         #expect(viewModel.messageBus.currentMessage?.message ==
-            "\(Strings.shopDeletedError) [NATI-2001] \(message) [Status: \(httpResponseCode)]")
+            "\(Strings.shopDeletedError) [NATIVEAPPTEMPLATE-2001] \(message) [Status: \(httpResponseCode)]")
         #expect(viewModel.isDeleting)
         #expect(viewModel.isBusy)
         #expect(sessionController.userState == .notLoggedIn)

--- a/NativeAppTemplateTests/Utilities/AppErrorTest.swift
+++ b/NativeAppTemplateTests/Utilities/AppErrorTest.swift
@@ -11,7 +11,7 @@ struct AppErrorTest {
     @Test
     func unexpectedErrorCode() {
         let error = AppError.unexpected(description: "Something broke")
-        #expect(error.errorCode == "NATI-1001")
+        #expect(error.errorCode == "NATIVEAPPTEMPLATE-1001")
     }
 
     @Test
@@ -23,7 +23,7 @@ struct AppErrorTest {
     @Test
     func unexpectedFormattedDescription() {
         let error = AppError.unexpected(description: "Something broke")
-        #expect(error.formattedDescription == "[NATI-1001] An unexpected error occurred. Something broke")
+        #expect(error.formattedDescription == "[NATIVEAPPTEMPLATE-1001] An unexpected error occurred. Something broke")
     }
 
     @Test
@@ -34,7 +34,7 @@ struct AppErrorTest {
             line: 42,
             function: "testFunc()"
         )
-        #expect(error.debugDescription.contains("NATI-1001"))
+        #expect(error.debugDescription.contains("NATIVEAPPTEMPLATE-1001"))
         #expect(error.debugDescription.contains("Something broke"))
         #expect(error.debugDescription.contains("TestFile.swift"))
         #expect(error.debugDescription.contains("42"))
@@ -44,6 +44,6 @@ struct AppErrorTest {
     @Test
     func codedDescriptionViaErrorExtension() {
         let error: Error = AppError.unexpected(description: "Test")
-        #expect(error.codedDescription == "[NATI-1001] An unexpected error occurred. Test")
+        #expect(error.codedDescription == "[NATIVEAPPTEMPLATE-1001] An unexpected error occurred. Test")
     }
 }

--- a/NativeAppTemplateTests/Utilities/CodedErrorTest.swift
+++ b/NativeAppTemplateTests/Utilities/CodedErrorTest.swift
@@ -10,20 +10,20 @@ import Testing
 @Suite
 struct CodedErrorTest {
     struct TestCodedError: CodedError {
-        var errorCode: String { "NATI-9999" }
+        var errorCode: String { "NATIVEAPPTEMPLATE-9999" }
         var errorDescription: String? { "Test error description" }
     }
 
     @Test
     func formattedDescription() {
         let error = TestCodedError()
-        #expect(error.formattedDescription == "[NATI-9999] Test error description")
+        #expect(error.formattedDescription == "[NATIVEAPPTEMPLATE-9999] Test error description")
     }
 
     @Test
     func codedDescriptionWithCodedError() {
         let error: Error = TestCodedError()
-        #expect(error.codedDescription == "[NATI-9999] Test error description")
+        #expect(error.codedDescription == "[NATIVEAPPTEMPLATE-9999] Test error description")
     }
 
     @Test
@@ -37,13 +37,13 @@ struct CodedErrorTest {
     }
 
     struct NilDescriptionError: CodedError {
-        var errorCode: String { "NATI-0000" }
+        var errorCode: String { "NATIVEAPPTEMPLATE-0000" }
         var errorDescription: String? { nil }
     }
 
     @Test
     func formattedDescriptionWithNilErrorDescription() {
         let error = NilDescriptionError()
-        #expect(error.formattedDescription == "[NATI-0000] Unknown error")
+        #expect(error.formattedDescription == "[NATIVEAPPTEMPLATE-0000] Unknown error")
     }
 }

--- a/NativeAppTemplateTests/Utilities/MessageBusTest.swift
+++ b/NativeAppTemplateTests/Utilities/MessageBusTest.swift
@@ -79,7 +79,7 @@ struct MessageBusTest {
         let message = Message(error: error)
 
         #expect(message.level == .error)
-        #expect(message.message == "[NATI-2005] NativeAppTemplateAPIError::NoData")
+        #expect(message.message == "[NATIVEAPPTEMPLATE-2005] NativeAppTemplateAPIError::NoData")
         #expect(message.autoDismiss == false)
     }
 

--- a/NativeAppTemplateTests/Utilities/NativeAppTemplateAPIErrorTest.swift
+++ b/NativeAppTemplateTests/Utilities/NativeAppTemplateAPIErrorTest.swift
@@ -11,38 +11,38 @@ struct NativeAppTemplateAPIErrorTest {
     @Test
     func requestFailedErrorCode() {
         let error = NativeAppTemplateAPIError.requestFailed(nil, 500, "Server error")
-        #expect(error.errorCode == "NATI-2001")
+        #expect(error.errorCode == "NATIVEAPPTEMPLATE-2001")
     }
 
     @Test
     func processingErrorErrorCode() {
         let error = NativeAppTemplateAPIError.processingError(nil)
-        #expect(error.errorCode == "NATI-2002")
+        #expect(error.errorCode == "NATIVEAPPTEMPLATE-2002")
     }
 
     @Test
     func responseMissingRequiredMetaErrorCode() {
         let error = NativeAppTemplateAPIError.responseMissingRequiredMeta(field: "total")
-        #expect(error.errorCode == "NATI-2003")
+        #expect(error.errorCode == "NATIVEAPPTEMPLATE-2003")
     }
 
     @Test
     func responseHasIncorrectNumberOfElementsErrorCode() {
         let error = NativeAppTemplateAPIError.responseHasIncorrectNumberOfElements
-        #expect(error.errorCode == "NATI-2004")
+        #expect(error.errorCode == "NATIVEAPPTEMPLATE-2004")
     }
 
     @Test
     func noDataErrorCode() {
         let error = NativeAppTemplateAPIError.noData
-        #expect(error.errorCode == "NATI-2005")
+        #expect(error.errorCode == "NATIVEAPPTEMPLATE-2005")
     }
 
     @Test
     func requestFailedWithMessage() {
         let error = NativeAppTemplateAPIError.requestFailed(nil, 422, "Validation failed")
         #expect(error.errorDescription == "Validation failed [Status: 422]")
-        #expect(error.formattedDescription == "[NATI-2001] Validation failed [Status: 422]")
+        #expect(error.formattedDescription == "[NATIVEAPPTEMPLATE-2001] Validation failed [Status: 422]")
     }
 
     @Test
@@ -84,12 +84,12 @@ struct NativeAppTemplateAPIErrorTest {
     func noDataDescription() {
         let error = NativeAppTemplateAPIError.noData
         #expect(error.errorDescription == "NativeAppTemplateAPIError::NoData")
-        #expect(error.formattedDescription == "[NATI-2005] NativeAppTemplateAPIError::NoData")
+        #expect(error.formattedDescription == "[NATIVEAPPTEMPLATE-2005] NativeAppTemplateAPIError::NoData")
     }
 
     @Test
     func codedDescriptionViaErrorExtension() {
         let error: Error = NativeAppTemplateAPIError.requestFailed(nil, 404, "Not found")
-        #expect(error.codedDescription == "[NATI-2001] Not found [Status: 404]")
+        #expect(error.codedDescription == "[NATIVEAPPTEMPLATE-2001] Not found [Status: 404]")
     }
 }

--- a/README.md
+++ b/README.md
@@ -142,12 +142,12 @@ To run this app successfully, ensure you have:
 To connect to a local API server, set these env vars on the Xcode scheme (Edit Scheme → Run → Arguments → Environment Variables):
 
 ```
-NATEMPLATE_API_SCHEME = http
-NATEMPLATE_API_DOMAIN = <your-lan-ip>
-NATEMPLATE_API_PORT   = 3000
+NATIVEAPPTEMPLATE_API_SCHEME = http
+NATIVEAPPTEMPLATE_API_DOMAIN = <your-lan-ip>
+NATIVEAPPTEMPLATE_API_PORT   = 3000
 ```
 
-> **Note:** Never use `127.0.0.1`, `localhost`, or `0.0.0.0` for `NATEMPLATE_API_DOMAIN` — those resolve to the iOS Simulator/device itself, not your Mac. Use your Mac's LAN IP (e.g., `192.168.1.6`) so the simulator or a physical device can reach the API server.
+> **Note:** Never use `127.0.0.1`, `localhost`, or `0.0.0.0` for `NATIVEAPPTEMPLATE_API_DOMAIN` — those resolve to the iOS Simulator/device itself, not your Mac. Use your Mac's LAN IP (e.g., `192.168.1.6`) so the simulator or a physical device can reach the API server.
 
 Keep the scheme in `xcuserdata` (per-developer, gitignored), not `xcshareddata`. In Xcode, open **Product → Scheme → Manage Schemes…**, find `NativeAppTemplate`, and **uncheck "Shared"**. This moves the scheme (with your local env vars) to `xcuserdata/<user>.xcuserdatad/xcschemes/` so your API settings are not committed. If Xcode staged a deletion of the previously shared scheme, restore it with:
 


### PR DESCRIPTION
## Summary
Eliminate the two abbreviations the upstream agent's Layer 1 renamer can't reach so `NativeAppTemplate -> <slug>` covers every product-name occurrence. Mirrors upstream PR [nativeapptemplate/NativeAppTemplate-iOS#71](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/71).

- **Env vars:** `NATEMPLATE_API_{SCHEME,DOMAIN,PORT}` -> `NATIVEAPPTEMPLATE_API_*` in `Constants.swift`, `README.md`, and the local `.xcscheme` (gitignored, updated locally)
- **Error codes:** `NATI-XXXX` -> `NATIVEAPPTEMPLATE-XXXX` across all production and test Swift files, plus `CHANGELOG.md`
- **CLAUDE.md:** error-code section reframed as a shared iOS+Android prefix; dropped the stale `NFCError.swift` / `NATIVEAPPTEMPLATE-3xxx` row (file is not present in this fork)

After this lands, `rg -n "NATEMPLATE_API|NATI-"` outside `docs-private/` matches nothing.

## Test plan
- [x] `make lint` (0 violations, SwiftFormat clean)
- [x] `xcodebuild build` (Debug, iPhone 17 Pro / iOS 26.2) succeeds
- [x] `xcodebuild test` for `AppErrorTest`, `CodedErrorTest`, `NativeAppTemplateAPIErrorTest`, `MessageBusTest`, and the four touched ViewModel tests — all pass
- [ ] Smoke-test against a local API server: re-export the env vars under their new names (`NATIVEAPPTEMPLATE_API_DOMAIN`, etc.) in the Xcode scheme — the old `NATEMPLATE_API_*` names will no longer be picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)