### PR TITLE
Clarify Shop list card tag labels as item tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.1] - 2026-05-02
+
+### Changed
+- Clarify Shop list card tag labels as "completed item tags" / "all item tags"
+
 ## [3.2.0] - 2026-05-02
 
 ### Removed

--- a/NativeAppTemplate.xcodeproj/project.pbxproj
+++ b/NativeAppTemplate.xcodeproj/project.pbxproj
@@ -1205,7 +1205,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_ASSET_PATHS = "\"NativeAppTemplate/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1217,7 +1217,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				PRODUCT_NAME = NativeAppTemplate;
@@ -1241,7 +1241,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_ASSET_PATHS = "\"NativeAppTemplate/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1253,7 +1253,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				PRODUCT_NAME = NativeAppTemplate;

--- a/NativeAppTemplate/UI/Shop List/ShopListCardView.swift
+++ b/NativeAppTemplate/UI/Shop List/ShopListCardView.swift
@@ -27,7 +27,7 @@ struct ShopListCardView: View {
                         .foregroundStyle(.secondaryText)
                     Text(String(shop.completedItemTagsCount))
                         .font(.uiLabelBold)
-                    Text(verbatim: "completed tags")
+                    Text(verbatim: "completed item tags")
                         .font(.uiFootnote)
                         .foregroundStyle(.contentText)
                 }
@@ -38,7 +38,7 @@ struct ShopListCardView: View {
                         .foregroundStyle(.secondaryText)
                     Text(String(shop.itemTagsCount))
                         .font(.uiLabelBold)
-                    Text(verbatim: "all tags")
+                    Text(verbatim: "all item tags")
                         .font(.uiFootnote)
                         .foregroundStyle(.contentText)
                 }


### PR DESCRIPTION
## Summary
- Rename Shop list card stat labels from "completed tags" / "all tags" to "completed item tags" / "all item tags"
- Aligns visible labels with the recent Number Tag → Item Tag terminology rename (#47)

## Test plan
- [ ] Open the Shop list and confirm each card shows "completed item tags" and "all item tags" beside the counts
- [ ] `make lint` passes
- [ ] Tests pass in Xcode (Cmd+U)

🤖 Generated with [Claude Code](https://claude.com/claude-code)