### PR TITLE
Remove unused shop reset functionality

### DIFF
--- a/NativeAppTemplate/Data/Repositories/ShopRepository.swift
+++ b/NativeAppTemplate/Data/Repositories/ShopRepository.swift
@@ -109,15 +109,4 @@ import SwiftUI
             throw error
         }
     }
-
-    func reset(id: String) async throws {
-        do {
-            try await shopsService.resetShop(id: id)
-        } catch {
-            Failure
-                .destroy(from: Self.self, reason: error.codedDescription)
-                .log()
-            throw error
-        }
-    }
 }

--- a/NativeAppTemplate/Data/Repositories/ShopRepositoryProtocol.swift
+++ b/NativeAppTemplate/Data/Repositories/ShopRepositoryProtocol.swift
@@ -20,5 +20,4 @@ import SwiftUI
     func create(shop: Shop) async throws -> Shop
     func update(id: String, shop: Shop) async throws -> Shop
     func destroy(id: String) async throws
-    func reset(id: String) async throws
 }

--- a/NativeAppTemplate/Networking/Requests/ShopsRequest.swift
+++ b/NativeAppTemplate/Networking/Requests/ShopsRequest.swift
@@ -183,30 +183,3 @@ struct DestroyShopRequest: Request {
 
     func handle(response: Data) throws {}
 }
-
-struct ResetShopRequest: Request {
-    typealias Response = Void
-
-    // MARK: - Properties
-
-    var method: HTTPMethod {
-        .DELETE
-    }
-
-    var path: String {
-        "/shopkeeper/shops/\(id)/reset"
-    }
-
-    var additionalHeaders: [String: String] = [:]
-    var body: Data? {
-        nil
-    }
-
-    // MARK: - Parameters
-
-    let id: String
-
-    // MARK: - Internal
-
-    func handle(response: Data) throws {}
-}

--- a/NativeAppTemplate/Networking/Services/ShopsService.swift
+++ b/NativeAppTemplate/Networking/Services/ShopsService.swift
@@ -31,8 +31,4 @@ extension ShopsService {
         let request = MakeShopRequest(shop: shop)
         return try await makeRequest(request: request)
     }
-
-    func resetShop(id: String) async throws -> ResetShopRequest.Response {
-        try await makeRequest(request: ResetShopRequest(id: id))
-    }
 }

--- a/NativeAppTemplateTests/Demo/Data/Repositories/DemoShopRepository.swift
+++ b/NativeAppTemplateTests/Demo/Data/Repositories/DemoShopRepository.swift
@@ -56,8 +56,6 @@ final class DemoShopRepository: ShopRepositoryProtocol {
         shops.removeAll { $0.id == id }
     }
 
-    func reset(id: String) async throws {}
-
     // MARK: - Helpers
 
     private func mockShop(id: String = UUID().uuidString, name: String = "Mock Shop") -> Shop {

--- a/NativeAppTemplateTests/Demo/Data/Repositories/DemoShopRepositoryTest.swift
+++ b/NativeAppTemplateTests/Demo/Data/Repositories/DemoShopRepositoryTest.swift
@@ -73,14 +73,5 @@ struct DemoShopRepositoryTest {
             try await repository.destroy(id: "1")
             #expect(!repository.shops.contains { $0.id == "1" })
         }
-
-        @Test
-        func reset() async throws {
-            repository.reload()
-
-            await #expect(throws: Never.self) {
-                try await repository.reset(id: "1")
-            }
-        }
     }
 }

--- a/NativeAppTemplateTests/Testing/Repositories/TestShopRepository.swift
+++ b/NativeAppTemplateTests/Testing/Repositories/TestShopRepository.swift
@@ -81,12 +81,6 @@ final class TestShopRepository: ShopRepositoryProtocol {
         shops.removeAll { $0.id == id }
     }
 
-    func reset(id: String) async throws {
-        guard error == nil else {
-            throw error!
-        }
-    }
-
     /// A test-only
     func setShops(shops: [Shop]) {
         self.shops = shops


### PR DESCRIPTION
## Summary
- Removes `ShopRepository.reset(id:)` and its `ShopRepositoryProtocol` declaration
- Drops the corresponding `ShopsService.resetShop` and `ResetShopRequest` networking layer
- Cleans up reset stubs in `DemoShopRepository`, `TestShopRepository`, and `DemoShopRepositoryTest`

Ports https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/73 to this repo.

## Test plan
- [x] `make lint` passes
- [x] Build succeeds in Xcode
- [x] Existing tests pass (Cmd+U)

🤖 Generated with [Claude Code](https://claude.com/claude-code)