### PR TITLE
Add welcome header to Onboarding screen

### DIFF
--- a/NativeAppTemplate/Constants.swift
+++ b/NativeAppTemplate/Constants.swift
@@ -285,6 +285,10 @@ enum Strings {
     static let email = "Email"
     static let password = "Password"
 
+    static var welcomeToApp: String {
+        "Welcome to \(Bundle.main.displayName)"
+    }
+
     static let onboardingDescription1 = "Onboarding description 1."
     static let onboardingDescription2 = "Onboarding description 2."
     static let onboardingDescription3 = "Onboarding description 3."

--- a/NativeAppTemplate/UI/App Root/OnboardingView.swift
+++ b/NativeAppTemplate/UI/App Root/OnboardingView.swift
@@ -26,6 +26,7 @@ private extension OnboardingView {
         @ViewBuilder var contentView: some View {
             VStack {
                 SwiftUI.TabView {
+                    welcomePage
                     ForEach(viewModel.onboardings) { onboarding in
                         let id = onboarding.id
                         page(
@@ -58,6 +59,31 @@ private extension OnboardingView {
             .resizable()
             .aspectRatio(contentMode: .fit)
             .frame(width: 256, height: 24)
+    }
+
+    private var welcomePage: some View {
+        ZStack(alignment: .bottom) {
+            Image("hero")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .padding(.top, NativeAppTemplateConstants.Spacing.md)
+                .padding(.bottom, 192)
+
+            ZStack(alignment: .top) {
+                VStack {
+                    Text(Strings.welcomeToApp)
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .multilineTextAlignment(.center)
+                        .dynamicTypeSize(DynamicTypeSize.accessibility1)
+                        .padding([.top, .horizontal])
+                        .accessibilityIdentifier("OnboardingView_welcome_staticText")
+                }
+                .background(Color.backgroundColor)
+                .frame(maxWidth: .infinity, maxHeight: 192, alignment: .top)
+            }
+            .background(Color.backgroundColor)
+        }
     }
 
     private func page(image: String, text: String, imageOrientation: ImageOrientation) -> some View {


### PR DESCRIPTION
## Summary
- Adds a bold "Welcome to {ProductName}" first page to the Onboarding `TabView`
- Introduces `Strings.welcomeToApp`, a computed property that interpolates `Bundle.main.displayName` so the product name stays driven by `CFBundleDisplayName`

Ports https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/74 to the Free repo.

## Test plan
- [x] `make lint` passes
- [x] Build succeeds in Xcode
- [x] Existing tests pass (Cmd+U)
- [x] Run on iOS Simulator: confirm "Welcome to NativeAppTemplate" appears as the first onboarding page and paging still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)