### PR TITLE
Drop articles before renameable domain words

### DIFF
--- a/NativeAppTemplate/Constants.swift
+++ b/NativeAppTemplate/Constants.swift
@@ -166,9 +166,9 @@ enum Strings {
 
     static let timeZone = "Time Zone"
     static let createShopsLabel = "Create shops"
-    static let tapShopBelow = "Tap a shop below."
+    static let tapShopBelow = "Tap shop below."
     static let haveFun = "Have fun!"
-    static let shopDetailInstruction = "Swipe an item tag to change its status."
+    static let shopDetailInstruction = "Swipe to change item tag status."
 
     // MARK: Shop Settings View
 
@@ -183,7 +183,7 @@ enum Strings {
     static let itemTagNamePlaceholder = "Name"
     static let editItemTag = "Edit Item Tag"
     static let addItemTag = "Add Item Tag"
-    static let addItemTagDescription = "Add a new item tag and start changing the item tag status."
+    static let addItemTagDescription = "Add a new item tag and start changing item tag status."
     static let deleteItemTag = "Delete item tag"
     static let buttonDeleteItemTag = "Delete Item Tag"
     static let itemTagNameIsInvalid = "Item tag name is invalid."
@@ -235,14 +235,14 @@ enum Strings {
     static let shopCreated = "Shop created successfully."
     static let basicSettingsUpdated = "Basic settings updated successfully."
     static let shopDeleted = "Shop deleted successfully."
-    static let shopDeletedError = "There was a problem deleting the shop."
+    static let shopDeletedError = "There was a problem deleting shop."
 
     static let itemTagCreated = "Item tag created successfully."
     static let itemTagUpdated = "Item tag updated successfully."
     static let itemTagDeleted = "Item tag deleted successfully."
-    static let itemTagDeletedError = "There was a problem deleting the item tag."
-    static let itemTagCompletedError = "There was a problem completing the item tag."
-    static let itemTagIdledError = "There was a problem idling the item tag."
+    static let itemTagDeletedError = "There was a problem deleting item tag."
+    static let itemTagCompletedError = "There was a problem completing item tag."
+    static let itemTagIdledError = "There was a problem idling item tag."
 
     static let shopkeeperCreated = "Account created successfully."
     static let shopkeeperCreatedError = "There was a problem creating the account."

--- a/NativeAppTemplateTests/Networking/Adapters/ShopAdapterTest.swift
+++ b/NativeAppTemplateTests/Networking/Adapters/ShopAdapterTest.swift
@@ -12,7 +12,7 @@ struct ShopAdapterTest {
         "type": "shop",
         "attributes": [
             "name": "Shop1",
-            "description": "This is a Shop1",
+            "description": "This is Shop1",
             "time_zone": "Tokyo",
             "item_tags_count": 10,
             "scanned_item_tags_count": 1,


### PR DESCRIPTION
## Summary
- Apply [`SUBSTRATE-CONTRACT.md`](https://github.com/nativeapptemplate/nativeapptemplate-agent/blob/main/docs/SUBSTRATE-CONTRACT.md) rule 1: UI strings must not couple articles to renameable domain nouns (`Shop`, `ItemTag`, `Shopkeeper`), so the agent's rename pipeline produces grammatical output for any target word (e.g. `"Swipe an item tag…"` → `"Swipe an patient…"` after `ItemTag → Patient`).
- 7 fixes in `NativeAppTemplate/Constants.swift` (UI/error strings) and 1 in `NativeAppTemplateTests/.../ShopAdapterTest.swift` (test fixture description). Audits for rules 2–7 (casing, irregular plurals, English-grammar templates, non-domain uses, comments) found no additional issues.
- One change matches the contract's "Also good" example verbatim: `shopDetailInstruction` becomes `"Swipe to change item tag status."`

## Test plan
- [x] `make lint` — 0 SwiftLint violations, 0 SwiftFormat issues
- [x] Verify tests pass in Xcode (Cmd+U)
- [ ] Spot-check the affected UI strings render correctly: Shop list empty state, item tag list empty/instruction, shop/item tag delete error toasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)