### PR TITLE
Make EntityAdapterError and KeychainStoreError conform to CodedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.3] - 2026-05-08
+
+### Fixed
+- `EntityAdapterError` (JSON:API parsing) now conforms to `CodedError` so failures — including login against an invalid server — surface with `[NATIVEAPPTEMPLATE-2006..2008]` prefixes instead of opaque descriptions
+- `KeychainStoreError` now conforms to `CodedError` with new `[NATIVEAPPTEMPLATE-4001..4004]` codes for persistence failures
+
 ## [3.2.2] - 2026-05-04
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,8 @@ All errors use the `CodedError` protocol in `NativeAppTemplate/Common/Errors/`. 
 | Range | Type | File |
 |-------|------|------|
 | NATIVEAPPTEMPLATE-1xxx | App/general errors | `AppError.swift` |
-| NATIVEAPPTEMPLATE-2xxx | API/network errors | `NativeAppTemplateAPIError.swift` |
+| NATIVEAPPTEMPLATE-2xxx | API/network errors | `NativeAppTemplateAPIError.swift`, `EntityAdapterError.swift` |
+| NATIVEAPPTEMPLATE-4xxx | Persistence/Keychain errors | `KeychainStoreError.swift` |
 
 - New error types must conform to `CodedError` and be placed in `Common/Errors/`
 - Use `error.codedDescription` (not `error.localizedDescription`) in all error messages

--- a/NativeAppTemplate.xcodeproj/project.pbxproj
+++ b/NativeAppTemplate.xcodeproj/project.pbxproj
@@ -149,6 +149,8 @@
 		A2B3C4D500000002 /* CodedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D500000001 /* CodedError.swift */; };
 		A2B3C4D500000004 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D500000003 /* AppError.swift */; };
 		A2B3C4D500000008 /* NativeAppTemplateAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D500000007 /* NativeAppTemplateAPIError.swift */; };
+		A2B3C4D50000000C /* EntityAdapterError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D50000000B /* EntityAdapterError.swift */; };
+		A2B3C4D50000000E /* KeychainStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D50000000D /* KeychainStoreError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -303,6 +305,8 @@
 		A2B3C4D500000001 /* CodedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodedError.swift; sourceTree = "<group>"; };
 		A2B3C4D500000003 /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		A2B3C4D500000007 /* NativeAppTemplateAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAppTemplateAPIError.swift; sourceTree = "<group>"; };
+		A2B3C4D50000000B /* EntityAdapterError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityAdapterError.swift; sourceTree = "<group>"; };
+		A2B3C4D50000000D /* KeychainStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStoreError.swift; sourceTree = "<group>"; };
 		C597C0551370446BB931F19B /* CertificatePinningDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatePinningDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -772,6 +776,8 @@
 			children = (
 				A2B3C4D500000003 /* AppError.swift */,
 				A2B3C4D500000001 /* CodedError.swift */,
+				A2B3C4D50000000B /* EntityAdapterError.swift */,
+				A2B3C4D50000000D /* KeychainStoreError.swift */,
 				A2B3C4D500000007 /* NativeAppTemplateAPIError.swift */,
 			);
 			path = Errors;
@@ -953,6 +959,8 @@
 				A2B3C4D500000002 /* CodedError.swift in Sources */,
 				A2B3C4D500000004 /* AppError.swift in Sources */,
 				A2B3C4D500000008 /* NativeAppTemplateAPIError.swift in Sources */,
+				A2B3C4D50000000C /* EntityAdapterError.swift in Sources */,
+				A2B3C4D50000000E /* KeychainStoreError.swift in Sources */,
 				01D8AE8B2AB453C1009AFFBA /* ShopBasicSettingsView.swift in Sources */,
 				01E0A60125BD149200298D35 /* MainButtonView.swift in Sources */,
 				A1B2C3D401000003 /* GlassCard.swift in Sources */,
@@ -1189,7 +1197,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_ASSET_PATHS = "\"NativeAppTemplate/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1201,7 +1209,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.2;
+				MARKETING_VERSION = 3.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				PRODUCT_NAME = NativeAppTemplate;
@@ -1225,7 +1233,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_ASSET_PATHS = "\"NativeAppTemplate/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1237,7 +1245,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.2;
+				MARKETING_VERSION = 3.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				PRODUCT_NAME = NativeAppTemplate;

--- a/NativeAppTemplate/Common/Errors/CodedError.swift
+++ b/NativeAppTemplate/Common/Errors/CodedError.swift
@@ -4,7 +4,10 @@
 //
 
 // Error codes share the `NATIVEAPPTEMPLATE-XXXX` prefix across iOS and Android.
-// Ranges: 1xxx App errors, 2xxx API errors.
+// Ranges:
+//   1xxx App errors
+//   2xxx API errors (NativeAppTemplateAPIError, EntityAdapterError)
+//   4xxx Persistence/Keychain errors (KeychainStoreError)
 
 import Foundation
 

--- a/NativeAppTemplate/Common/Errors/EntityAdapterError.swift
+++ b/NativeAppTemplate/Common/Errors/EntityAdapterError.swift
@@ -1,0 +1,37 @@
+//
+//  EntityAdapterError.swift
+//  NativeAppTemplate
+//
+
+import Foundation
+
+/// JSON:API response parsing errors
+/// Error codes: NATIVEAPPTEMPLATE-2006 to NATIVEAPPTEMPLATE-2008
+enum EntityAdapterError: CodedError {
+    case invalidResourceTypeForAdapter
+    case invalidOrMissingAttributes
+    case invalidOrMissingRelationships
+
+    nonisolated var errorCode: String {
+        switch self {
+        case .invalidResourceTypeForAdapter:
+            "NATIVEAPPTEMPLATE-2006"
+        case .invalidOrMissingAttributes:
+            "NATIVEAPPTEMPLATE-2007"
+        case .invalidOrMissingRelationships:
+            "NATIVEAPPTEMPLATE-2008"
+        }
+    }
+
+    nonisolated var errorDescription: String? {
+        let prefix = "EntityAdapterError::"
+        switch self {
+        case .invalidResourceTypeForAdapter:
+            return "\(prefix)InvalidResourceTypeForAdapter"
+        case .invalidOrMissingAttributes:
+            return "\(prefix)InvalidOrMissingAttributes"
+        case .invalidOrMissingRelationships:
+            return "\(prefix)InvalidOrMissingRelationships"
+        }
+    }
+}

--- a/NativeAppTemplate/Common/Errors/KeychainStoreError.swift
+++ b/NativeAppTemplate/Common/Errors/KeychainStoreError.swift
@@ -1,0 +1,41 @@
+//
+//  KeychainStoreError.swift
+//  NativeAppTemplate
+//
+
+import Foundation
+
+/// Keychain persistence errors
+/// Error codes: NATIVEAPPTEMPLATE-4001 to NATIVEAPPTEMPLATE-4004
+enum KeychainStoreError: CodedError {
+    case secCallFailed(Error)
+    case notFound
+    case badData
+    case archiveFailure(Error)
+
+    nonisolated var errorCode: String {
+        switch self {
+        case .secCallFailed:
+            "NATIVEAPPTEMPLATE-4001"
+        case .notFound:
+            "NATIVEAPPTEMPLATE-4002"
+        case .badData:
+            "NATIVEAPPTEMPLATE-4003"
+        case .archiveFailure:
+            "NATIVEAPPTEMPLATE-4004"
+        }
+    }
+
+    nonisolated var errorDescription: String? {
+        switch self {
+        case let .secCallFailed(error):
+            "KeychainStoreError::SecCallFailed[Error: \(error.localizedDescription)]"
+        case .notFound:
+            "KeychainStoreError::NotFound"
+        case .badData:
+            "KeychainStoreError::BadData"
+        case let .archiveFailure(error):
+            "KeychainStoreError::ArchiveFailure[Error: \(error.localizedDescription)]"
+        }
+    }
+}

--- a/NativeAppTemplate/Networking/Adapters/EntityAdapter.swift
+++ b/NativeAppTemplate/Networking/Adapters/EntityAdapter.swift
@@ -47,23 +47,3 @@ struct EntityRelationship {
     let from: EntityIdentity
     let to: EntityIdentity
 }
-
-enum EntityAdapterError: Error {
-    case invalidResourceTypeForAdapter
-    case invalidOrMissingAttributes
-    case invalidOrMissingRelationships
-}
-
-extension EntityAdapterError: LocalizedError {
-    var errorDescription: String? {
-        let prefix = "EntityAdapterError::"
-        switch self {
-        case .invalidResourceTypeForAdapter:
-            return "\(prefix)InvalidResourceTypeForAdapter"
-        case .invalidOrMissingAttributes:
-            return "\(prefix)InvalidOrMissingAttributes"
-        case .invalidOrMissingRelationships:
-            return "\(prefix)InvalidOrMissingRelationships"
-        }
-    }
-}

--- a/NativeAppTemplate/Persistence/KeychainStore/KeychainStore.swift
+++ b/NativeAppTemplate/Persistence/KeychainStore/KeychainStore.swift
@@ -7,13 +7,6 @@ import Foundation
 import KeychainAccess
 import os
 
-enum KeychainStoreError: Error {
-    case secCallFailed(Error)
-    case notFound
-    case badData
-    case archiveFailure(Error)
-}
-
 protocol KeychainStore {
     associatedtype DataType: NSObject, NSCoding
 

--- a/NativeAppTemplateTests/Common/Errors/EntityAdapterErrorTest.swift
+++ b/NativeAppTemplateTests/Common/Errors/EntityAdapterErrorTest.swift
@@ -1,0 +1,40 @@
+//
+//  EntityAdapterErrorTest.swift
+//  NativeAppTemplate
+//
+
+@testable import NativeAppTemplate
+import Testing
+
+@Suite
+struct EntityAdapterErrorTest {
+    @Test
+    func errorCodes() {
+        #expect(EntityAdapterError.invalidResourceTypeForAdapter.errorCode == "NATIVEAPPTEMPLATE-2006")
+        #expect(EntityAdapterError.invalidOrMissingAttributes.errorCode == "NATIVEAPPTEMPLATE-2007")
+        #expect(EntityAdapterError.invalidOrMissingRelationships.errorCode == "NATIVEAPPTEMPLATE-2008")
+    }
+
+    @Test
+    func formattedDescriptions() {
+        #expect(
+            EntityAdapterError.invalidResourceTypeForAdapter.formattedDescription
+                == "[NATIVEAPPTEMPLATE-2006] EntityAdapterError::InvalidResourceTypeForAdapter"
+        )
+        #expect(
+            EntityAdapterError.invalidOrMissingAttributes.formattedDescription
+                == "[NATIVEAPPTEMPLATE-2007] EntityAdapterError::InvalidOrMissingAttributes"
+        )
+        #expect(
+            EntityAdapterError.invalidOrMissingRelationships.formattedDescription
+                == "[NATIVEAPPTEMPLATE-2008] EntityAdapterError::InvalidOrMissingRelationships"
+        )
+    }
+
+    @Test
+    func codedDescriptionPrependsCode() {
+        let error: Error = EntityAdapterError.invalidOrMissingAttributes
+
+        #expect(error.codedDescription == "[NATIVEAPPTEMPLATE-2007] EntityAdapterError::InvalidOrMissingAttributes")
+    }
+}

--- a/NativeAppTemplateTests/Common/Errors/KeychainStoreErrorTest.swift
+++ b/NativeAppTemplateTests/Common/Errors/KeychainStoreErrorTest.swift
@@ -1,0 +1,40 @@
+//
+//  KeychainStoreErrorTest.swift
+//  NativeAppTemplate
+//
+
+@testable import NativeAppTemplate
+import Foundation
+import Testing
+
+@Suite
+struct KeychainStoreErrorTest {
+    @Test
+    func errorCodes() {
+        let underlying = NSError(domain: "test", code: 1)
+
+        #expect(KeychainStoreError.secCallFailed(underlying).errorCode == "NATIVEAPPTEMPLATE-4001")
+        #expect(KeychainStoreError.notFound.errorCode == "NATIVEAPPTEMPLATE-4002")
+        #expect(KeychainStoreError.badData.errorCode == "NATIVEAPPTEMPLATE-4003")
+        #expect(KeychainStoreError.archiveFailure(underlying).errorCode == "NATIVEAPPTEMPLATE-4004")
+    }
+
+    @Test
+    func formattedDescriptions() {
+        #expect(
+            KeychainStoreError.notFound.formattedDescription
+                == "[NATIVEAPPTEMPLATE-4002] KeychainStoreError::NotFound"
+        )
+        #expect(
+            KeychainStoreError.badData.formattedDescription
+                == "[NATIVEAPPTEMPLATE-4003] KeychainStoreError::BadData"
+        )
+    }
+
+    @Test
+    func codedDescriptionPrependsCode() {
+        let error: Error = KeychainStoreError.notFound
+
+        #expect(error.codedDescription == "[NATIVEAPPTEMPLATE-4002] KeychainStoreError::NotFound")
+    }
+}


### PR DESCRIPTION
## Summary
- `EntityAdapterError` (JSON:API parsing) now conforms to `CodedError` with codes `NATIVEAPPTEMPLATE-2006..2008`, so failures — including logging in against an invalid server — surface with the standard `[NATIVEAPPTEMPLATE-XXXX]` prefix instead of an opaque description.
- `KeychainStoreError` now conforms to `CodedError` and claims a new `NATIVEAPPTEMPLATE-4xxx` range for persistence failures (`4001..4004`).
- Adds unit tests for both error types, updates `CodedError`/`CLAUDE.md` docs, and bumps version to 3.2.3 (build 13).
- Mirrors [NativeAppTemplate-iOS#78](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/78).

## Test plan
- [x] `make lint` passes (SwiftLint + SwiftFormat, 0 violations across 136 files)
- [x] `xcodebuild build` succeeds (iPhone 17 / iOS 26.2)
- [x] `EntityAdapterErrorTest` and `KeychainStoreErrorTest` pass via `xcodebuild test`
- [ ] Trigger a failed login against an invalid server and confirm the error message is prefixed with `[NATIVEAPPTEMPLATE-2007]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)