### PR TITLE
contributing: link to rename-safety contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,16 @@ Architecture: Simple MVVM Layered Architecture with `@Observable` state manageme
 - Tests use [Swift Testing](https://developer.apple.com/xcode/swift-testing/).
 - Place new tests alongside existing ones mirroring the source structure.
 
+## Rename safety
+
+This substrate is consumed by [`nativeapptemplate-agent`](https://github.com/nativeapptemplate/nativeapptemplate-agent), which mechanically renames `Shop`, `Shopkeeper`, and `ItemTag` (and all their case forms — PascalCase, snake_case, camelCase, flat, UPPER_SNAKE, humanized lower/title/sentence × singular/plural) to user-chosen target words. Some patterns that read fine in this repo break when renamed.
+
+Before merging changes that touch user-facing strings, test descriptors, or comments mentioning domain entities, read the [substrate rename-safety contract](https://github.com/nativeapptemplate/nativeapptemplate-agent/blob/main/docs/SUBSTRATE-CONTRACT.md).
+
+**Quick rule of thumb:** avoid `"a"` / `"an"` directly preceding `Shop`, `Shopkeeper`, or `ItemTag` (or their humanized forms) — write self-contained or article-free phrasings instead.
+
+**Failure mode this prevents:** a string like `"Swipe an item tag to ..."` reads correctly here but produces `"Swipe an patient to ..."` after the rename pipeline substitutes a consonant-starting word like `Patient`.
+
 ## Development Setup
 
 See [README.md](README.md) for full setup instructions.


### PR DESCRIPTION
## Summary
- Add a new `## Rename safety` section to `CONTRIBUTING.md` that links to the canonical [`SUBSTRATE-CONTRACT.md`](https://github.com/nativeapptemplate/nativeapptemplate-agent/blob/main/docs/SUBSTRATE-CONTRACT.md) in the agent repo.
- Includes a quick rule of thumb (avoid `a`/`an` before `Shop`/`Shopkeeper`/`ItemTag`) and the concrete failure mode (`"Swipe an item tag to ..."` → `"Swipe an patient to ..."` after rename).
- Placed after the Pull Requests group (Style/Tests subsections) so it doesn't interrupt existing subsections, and before Development Setup.

## Why
The agent at `nativeapptemplate-agent` mechanically renames domain words across all case forms when generating customized projects. Without a link from the substrate's natural contributor onboarding path, the contract doc only reaches contributors who already know to look in the agent repo.

## Test plan
- [x] CONTRIBUTING.md renders correctly in GitHub markdown preview
- [x] Links resolve to the agent repo's `SUBSTRATE-CONTRACT.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)