### PR TITLE
Make default scheme shared so generated projects ship with one

### DIFF
--- a/NativeAppTemplate.xcodeproj/xcshareddata/xcschemes/NativeAppTemplate.xcscheme
+++ b/NativeAppTemplate.xcodeproj/xcshareddata/xcschemes/NativeAppTemplate.xcscheme
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "011F6DEC259EF16400BED22E"
+               BuildableName = "NativeAppTemplate.app"
+               BlueprintName = "NativeAppTemplate"
+               ReferencedContainer = "container:NativeAppTemplate.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "01D19B422D4DE33500BDEAB7"
+               BuildableName = "NativeAppTemplateTests.xctest"
+               BlueprintName = "NativeAppTemplateTests"
+               ReferencedContainer = "container:NativeAppTemplate.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "011F6DEC259EF16400BED22E"
+            BuildableName = "NativeAppTemplate.app"
+            BlueprintName = "NativeAppTemplate"
+            ReferencedContainer = "container:NativeAppTemplate.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "shopkeeperBackdoorToken FILL_THIS_IN"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "NATIVEAPPTEMPLATE_API_SCHEME"
+            value = "http"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "NATIVEAPPTEMPLATE_API_DOMAIN"
+            value = "192.168.1.11"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "NATIVEAPPTEMPLATE_API_PORT"
+            value = "3000"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "011F6DEC259EF16400BED22E"
+            BuildableName = "NativeAppTemplate.app"
+            BlueprintName = "NativeAppTemplate"
+            ReferencedContainer = "container:NativeAppTemplate.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary
Move `NativeAppTemplate.xcscheme` from `xcuserdata/<user>.xcuserdatad/xcschemes/` to `xcshareddata/xcschemes/`.

`xcuserdata/` is gitignored (correctly — it holds per-developer Xcode state), which means anyone cloning fresh opens the project without a scheme until Xcode auto-creates a default one. The auto-default omits the run-time environment-variable injection (`NATIVEAPPTEMPLATE_API_DOMAIN`, `NATIVEAPPTEMPLATE_API_PORT`, `NATIVEAPPTEMPLATE_API_SCHEME`) the substrate relies on, so the app silently falls back to `api.nativeapptemplate.com` and any local-dev workflow breaks.

Shared schemes are the conventional Xcode pattern for any project meant to be cloned by others — no per-user state in the file, just the build/run/test configuration plus the env-var injection block. Promoting the default scheme to shared makes the substrate work out-of-the-box for:
- Fresh clones by external contributors
- The `nativeapptemplate-agent` code generator's `./out/<slug>/ios/` outputs (the agent's iOS worker copies the substrate but skips `xcuserdata`; it does *not* skip `xcshareddata`, so the moved scheme rides along)

## Companion PRs
- `NativeAppTemplate-iOS` (paid) — same move
- `nativeapptemplate-agent#64` — agent-side env-bridge that mirrors `NATIVEAPPTEMPLATE_API_*` to the renamed `<PRODUCT>_API_*` at run time, so the agent's automated validation runs work even before users open the generated project in Xcode

## Test plan
- [ ] `xcodebuild -scheme NativeAppTemplate -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' build` succeeds (CI covers this)
- [ ] Fresh clone in a new directory shows the scheme in Xcode's Scheme dropdown without manual setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)