### PR TITLE
swiftlint: run on every PR (drop paths filter)

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -2,10 +2,6 @@ name: SwiftLint
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/swiftlint.yml'
-      - '.swiftlint.yml'
-      - 'NativeAppTemplate/**/*.swift'
 
 jobs:
   SwiftLint:


### PR DESCRIPTION
## Summary
The previous `paths:` filter only triggered SwiftLint on changes to `.swiftlint.yml`, the workflow itself, or `*.swift` files. Branch protection on `main` marks SwiftLint as a required check — when a PR doesn't touch any of those paths (e.g. a `.xcscheme` move, `.gitignore` tweak, README edit), SwiftLint never runs and the PR is stuck in `BLOCKED` state because the required check has no status.

Standard pattern for required checks is to run on every PR. Cost is ~30s per PR for an action that early-exits when no Swift files changed. Worth it to avoid silent merge-blockage on infrastructure PRs.

Surfaced by #69 (move default scheme to xcshareddata) — same kind of issue will hit any future non-Swift-touching PR.

## Test plan
- [x] This PR itself touches `.github/workflows/swiftlint.yml` so it triggers SwiftLint regardless of the change here (the workflow file path is in the filter)
- [ ] After merge, push an empty commit to #69 to re-trigger CI; SwiftLint runs, PR becomes mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)