### PR TITLE
docs(readme): list Push Notifications (APNs) as a paid-only feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The full versions ([NativeAppTemplate-iOS (Solo)](https://nativeapptemplate.com/
 - User Invitation to Organizations
 - Role-Based Permissions and Access Control
 - Organization Switching UI
+- Push Notifications via APNs
 
 ## Supported Devices
 


### PR DESCRIPTION
## What

Adds `Push Notifications via APNs` to the **Not Included in the Free Version** list in the README.

## Why

The paid iOS README already lists push as a free-version exclusion ("Push Notifications via APNs (feature not included in free version)"), but this repo's exclusion list omitted it — an inconsistency between the two editions' docs.

Verified the free app ships **no** push code: no `Push/` directory, no APNs/UNUserNotification/remote-notification references anywhere in the source. So push is genuinely paid-only, and the README now reflects the actual feature boundary.

## Scope

Documentation only — one line added. No code changes.