### PR TITLE
Fix list reload blink and bump to 3.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.4] - 2026-06-10
+
+### Fixed
+- List views (`ShopListView`, `ItemTagListView`) no longer blink a full-screen `LoadingView` over already-loaded data when they re-appear (returning to a tab, popping back from a detail). The `.loading` state now keeps existing content on screen and only shows `LoadingView` on a true cold start (`.initial`, or `.loading` with no data yet)
+
 ## [3.2.3] - 2026-05-08
 
 ### Fixed

--- a/NativeAppTemplate.xcodeproj/project.pbxproj
+++ b/NativeAppTemplate.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 90;
+	objectVersion = 100;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -868,7 +868,7 @@
 				0182D36E25B258A7001E881D /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 				012009F6299F1E190078A1F9 /* XCRemoteSwiftPackageReference "swift-collections" */,
 			);
-			preferredProjectObjectVersion = 90;
+			preferredProjectObjectVersion = 100;
 			productRefGroup = 011F6DEE259EF16400BED22E /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/NativeAppTemplate.xcodeproj/project.pbxproj
+++ b/NativeAppTemplate.xcodeproj/project.pbxproj
@@ -1197,7 +1197,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"NativeAppTemplate/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1209,7 +1209,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.3;
+				MARKETING_VERSION = 3.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				PRODUCT_NAME = NativeAppTemplate;
@@ -1233,7 +1233,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"NativeAppTemplate/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -1245,7 +1245,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.2.3;
+				MARKETING_VERSION = 3.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "com.nativeapptemplate.NativeAppTemplateFree.ios${SAMPLE_CODE_DISAMBIGUATOR}";
 				PRODUCT_NAME = NativeAppTemplate;

--- a/NativeAppTemplate.xcodeproj/xcshareddata/xcschemes/NativeAppTemplate.xcscheme
+++ b/NativeAppTemplate.xcodeproj/xcshareddata/xcschemes/NativeAppTemplate.xcscheme
@@ -75,7 +75,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "NATIVEAPPTEMPLATE_API_DOMAIN"
-            value = "192.168.1.11"
+            value = "192.168.1.21"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/NativeAppTemplate/UI/Shop List/ShopListView.swift
+++ b/NativeAppTemplate/UI/Shop List/ShopListView.swift
@@ -63,8 +63,16 @@ private extension ShopListView {
     var contentView: some View {
         @ViewBuilder var contentView: some View {
             switch viewModel.state {
-            case .initial, .loading:
+            case .initial:
                 LoadingView()
+            case .loading:
+                // Keep showing the existing list while refreshing so re-appearance
+                // reloads don't blink a full-screen LoadingView over loaded data.
+                if viewModel.isEmpty {
+                    LoadingView()
+                } else {
+                    shopListView
+                }
             case .hasData:
                 shopListView
             case .failed:

--- a/NativeAppTemplate/UI/Shop Settings/ItemTag List/ItemTagListView.swift
+++ b/NativeAppTemplate/UI/Shop Settings/ItemTag List/ItemTagListView.swift
@@ -31,8 +31,16 @@ private extension ItemTagListView {
                 LoadingView()
             } else {
                 switch viewModel.state {
-                case .initial, .loading:
+                case .initial:
                     LoadingView()
+                case .loading:
+                    // Keep showing the existing list while refreshing so re-appearance
+                    // reloads don't blink a full-screen LoadingView over loaded data.
+                    if viewModel.isEmpty {
+                        LoadingView()
+                    } else {
+                        itemTagListView
+                    }
                 case .hasData:
                     itemTagListView
                 case .failed:

--- a/README.md
+++ b/README.md
@@ -149,11 +149,15 @@ NATIVEAPPTEMPLATE_API_PORT   = 3000
 
 > **Note:** Never use `127.0.0.1`, `localhost`, or `0.0.0.0` for `NATIVEAPPTEMPLATE_API_DOMAIN` — those resolve to the iOS Simulator/device itself, not your Mac. Use your Mac's LAN IP (e.g., `192.168.1.6`) so the simulator or a physical device can reach the API server.
 
-Keep the scheme in `xcuserdata` (per-developer, gitignored), not `xcshareddata`. In Xcode, open **Product → Scheme → Manage Schemes…**, find `NativeAppTemplate`, and **uncheck "Shared"**. This moves the scheme (with your local env vars) to `xcuserdata/<user>.xcuserdatad/xcschemes/` so your API settings are not committed. If Xcode staged a deletion of the previously shared scheme, restore it with:
+The `NativeAppTemplate` scheme is **shared** (committed at `NativeAppTemplate.xcodeproj/xcshareddata/xcschemes/NativeAppTemplate.xcscheme`) so fresh clones and generated copies open with these env vars already wired — without it, Xcode's auto-created default omits the injection and Debug builds silently fall back to `https://api.nativeapptemplate.com`. The committed `NATIVEAPPTEMPLATE_API_DOMAIN` is just an example value (`192.168.1.11`); edit it to your own Mac's LAN IP.
+
+Because the scheme is committed, keep your personal LAN IP out of git. After editing the value locally, tell git to ignore your changes to the file:
 
 ```bash
-git restore --source=HEAD --staged --worktree NativeAppTemplate.xcodeproj/xcshareddata/xcschemes/NativeAppTemplate.xcscheme
+git update-index --skip-worktree NativeAppTemplate.xcodeproj/xcshareddata/xcschemes/NativeAppTemplate.xcscheme
 ```
+
+To resume tracking it (e.g. before intentionally committing a scheme change), run `git update-index --no-skip-worktree <same path>`.
 
 Debug builds read these at launch via `ProcessInfo.processInfo.environment` in `Constants.swift`; when unset, they fall back to the production defaults (`https://api.nativeapptemplate.com`). Release builds always use the production defaults.
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ NATIVEAPPTEMPLATE_API_PORT   = 3000
 
 > **Note:** Never use `127.0.0.1`, `localhost`, or `0.0.0.0` for `NATIVEAPPTEMPLATE_API_DOMAIN` — those resolve to the iOS Simulator/device itself, not your Mac. Use your Mac's LAN IP (e.g., `192.168.1.6`) so the simulator or a physical device can reach the API server.
 
-The `NativeAppTemplate` scheme is **shared** (committed at `NativeAppTemplate.xcodeproj/xcshareddata/xcschemes/NativeAppTemplate.xcscheme`) so fresh clones and generated copies open with these env vars already wired — without it, Xcode's auto-created default omits the injection and Debug builds silently fall back to `https://api.nativeapptemplate.com`. The committed `NATIVEAPPTEMPLATE_API_DOMAIN` is just an example value (`192.168.1.11`); edit it to your own Mac's LAN IP.
+The `NativeAppTemplate` scheme is **shared** (committed at `NativeAppTemplate.xcodeproj/xcshareddata/xcschemes/NativeAppTemplate.xcscheme`) so fresh clones and generated copies open with these env vars already wired — without it, Xcode's auto-created default omits the injection and Debug builds silently fall back to `https://api.nativeapptemplate.com`. The committed `NATIVEAPPTEMPLATE_API_DOMAIN` is just an example value (`192.168.1.21`); edit it to your own Mac's LAN IP.
 
 Because the scheme is committed, keep your personal LAN IP out of git. After editing the value locally, tell git to ignore your changes to the file:
 


### PR DESCRIPTION
## Summary

`ShopListView` and `ItemTagListView` flashed a full-screen `LoadingView` whenever they re-appeared (returning to a tab, popping back from a detail). Each `.task`/`onChange` reload sets the view-model state to `.loading`, which swapped the already-populated content for the spinner and back — a visible blink.

This PR makes `.loading` keep the existing content on screen and only shows `LoadingView` on a true cold start (`.initial`, or `.loading` with no data yet). Background refreshes (`.refreshable`, reappearance reloads) now update in place.

Ports the relevant subset of [NativeAppTemplate-iOS#87](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/87) — only the list views that exist in this substrate (the Free version has no `AccountListView`).

## Changes

- **Blink fix** in: `ShopListView`, `ItemTagListView`
- Bump project `objectVersion` 90 → 100 (Xcode upgraded the project format on open)
- Bump version to **3.2.4 (build 14)** and update CHANGELOG
- Update the committed scheme's example `NATIVEAPPTEMPLATE_API_DOMAIN` to `192.168.1.21` (matching upstream), keeping the README example in sync
- **README**: document the now-shared scheme (per #69) and the `git update-index --skip-worktree` approach for keeping a personal LAN IP out of git, replacing the stale "uncheck Shared / keep in `xcuserdata`" instructions

## Not ported

- `AccountListView` — does not exist in the Free substrate

## Test plan

- `make lint` passes (0 violations, 0 formatting changes)
- Verify in Xcode (Cmd+U)
- Manually: switch tabs / pop back from a detail and confirm lists no longer blink while still refreshing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
